### PR TITLE
quality cuts, zcat VAC, data model tweaks

### DIFF
--- a/AgnCats/notebooks/AGNQSO_summary_cat.ipynb
+++ b/AgnCats/notebooks/AGNQSO_summary_cat.ipynb
@@ -203,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 14,
    "id": "0eda9f7e-5e05-4217-8452-aae07a449f74",
    "metadata": {},
    "outputs": [
@@ -211,13 +211,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['TARGETID', 'Z', 'ZERR', 'ZWARN', 'SPECTYPE', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'MORPHTYPE', 'EBV_1', 'MASKBITS', 'DESI_TARGET', 'SCND_TARGET', 'COADD_NUMEXP', 'COADD_EXPTIME', 'CMX_TARGET', 'SV1_DESI_TARGET', 'SV2_DESI_TARGET', 'SV3_DESI_TARGET', 'SV1_SCND_TARGET', 'SV2_SCND_TARGET', 'SV3_SCND_TARGET', 'TSNR2_LYA', 'TSNR2_QSO', 'DELTA_CHI2_MGII', 'A_MGII', 'SIGMA_MGII', 'B_MGII', 'VAR_A_MGII', 'VAR_SIGMA_MGII', 'VAR_B_MGII', 'Z_RR', 'Z_QN', 'C_LYA', 'C_CIV', 'C_CIII', 'C_MgII', 'C_Hbeta', 'C_Halpha', 'Z_LYA', 'Z_CIV', 'Z_CIII', 'Z_MgII', 'Z_Hbeta', 'Z_Halpha', 'QSO_MASKBITS', 'HPXPIXEL', 'SURVEY', 'PROGRAM', 'TSNR2_LRG', 'SV_NSPEC', 'SV_PRIMARY', 'ZCAT_NSPEC', 'ZCAT_PRIMARY', 'QN_C_LINE_BEST', 'QN_C_LINE_SECOND_BEST', 'PHOTSYS', 'LS_ID', 'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'AGN_MASKBITS', 'AGN_TYPE']\n"
+      "['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'Z', 'ZERR', 'ZWARN', 'SPECTYPE', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'MORPHTYPE', 'EBV_1', 'MASKBITS', 'DESI_TARGET', 'SCND_TARGET', 'BGS_TARGET', 'COADD_NUMEXP', 'COADD_EXPTIME', 'CMX_TARGET', 'SV1_DESI_TARGET', 'SV2_DESI_TARGET', 'SV3_DESI_TARGET', 'SV1_BGS_TARGET', 'SV2_BGS_TARGET', 'SV3_BGS_TARGET', 'SV1_SCND_TARGET', 'SV2_SCND_TARGET', 'SV3_SCND_TARGET', 'TSNR2_LYA', 'TSNR2_QSO', 'TSNR2_LRG', 'DELTA_CHI2_MGII', 'A_MGII', 'SIGMA_MGII', 'B_MGII', 'VAR_A_MGII', 'VAR_SIGMA_MGII', 'VAR_B_MGII', 'Z_RR', 'Z_QN', 'C_LYA', 'C_CIV', 'C_CIII', 'C_MgII', 'C_Hbeta', 'C_Halpha', 'Z_LYA', 'Z_CIV', 'Z_CIII', 'Z_MgII', 'Z_Hbeta', 'Z_Halpha', 'SV_NSPEC', 'SV_PRIMARY', 'ZCAT_NSPEC', 'ZCAT_PRIMARY', 'QN_C_LINE_BEST', 'QN_C_LINE_SECOND_BEST', 'QSO_MASKBITS', 'AGN_MASKBITS', 'AGN_TYPE', 'PHOTSYS', 'LS_ID', 'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z']\n"
      ]
     }
    ],
    "source": [
     "# Data model\n",
-    "final_cols=['TARGETID','Z','ZERR','ZWARN','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC','MORPHTYPE','EBV_1','MASKBITS','DESI_TARGET','SCND_TARGET','COADD_NUMEXP','COADD_EXPTIME','CMX_TARGET','SV1_DESI_TARGET','SV2_DESI_TARGET','SV3_DESI_TARGET','SV1_SCND_TARGET','SV2_SCND_TARGET','SV3_SCND_TARGET','TSNR2_LYA','TSNR2_QSO','DELTA_CHI2_MGII','A_MGII','SIGMA_MGII','B_MGII','VAR_A_MGII','VAR_SIGMA_MGII','VAR_B_MGII','Z_RR','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','Z_LYA','Z_CIV','Z_CIII','Z_MgII','Z_Hbeta','Z_Halpha','QSO_MASKBITS','HPXPIXEL','SURVEY','PROGRAM','TSNR2_LRG','SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY','QN_C_LINE_BEST','QN_C_LINE_SECOND_BEST','PHOTSYS','LS_ID','FIBERFLUX_G','FIBERFLUX_R','FIBERFLUX_Z','FIBERTOTFLUX_G','FIBERTOTFLUX_R','FIBERTOTFLUX_Z','AGN_MASKBITS','AGN_TYPE']\n",
+    "#\n",
+    "# Question about whether to keep: \n",
+    "#  - LS_ID\n",
+    "#  - other Tractor cols (MORPHTYPE, MASKBITS, PHOTSYS)\n",
+    "#  - EBV_1 (where does this one come from? from joining two tables with EBV??)\n",
+    "#  - FIBERFLUX* and FIBERTOTFLUX*\n",
+    "#  + replaced HPXPIXEL with HEALPIX (updated name); added BGS targeting cols to find BGS_WISE\n",
+    "#\n",
+    "#\n",
+    "final_cols=['TARGETID','SURVEY','PROGRAM','HEALPIX','Z','ZERR','ZWARN','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC',\\\n",
+    "            'MORPHTYPE','EBV_1','MASKBITS',\\\n",
+    "            'DESI_TARGET','SCND_TARGET','BGS_TARGET','COADD_NUMEXP','COADD_EXPTIME','CMX_TARGET',\\\n",
+    "            'SV1_DESI_TARGET','SV2_DESI_TARGET','SV3_DESI_TARGET','SV1_BGS_TARGET','SV2_BGS_TARGET','SV3_BGS_TARGET',\\\n",
+    "            'SV1_SCND_TARGET','SV2_SCND_TARGET','SV3_SCND_TARGET',\\\n",
+    "            'TSNR2_LYA','TSNR2_QSO','TSNR2_LRG',\\\n",
+    "            'DELTA_CHI2_MGII','A_MGII','SIGMA_MGII','B_MGII','VAR_A_MGII','VAR_SIGMA_MGII','VAR_B_MGII',\\\n",
+    "            'Z_RR','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','Z_LYA','Z_CIV','Z_CIII','Z_MgII','Z_Hbeta','Z_Halpha',\\\n",
+    "            'SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY',\\\n",
+    "            'QN_C_LINE_BEST','QN_C_LINE_SECOND_BEST','QSO_MASKBITS','AGN_MASKBITS','AGN_TYPE',\\\n",
+    "            'PHOTSYS','LS_ID','FIBERFLUX_G','FIBERFLUX_R','FIBERFLUX_Z','FIBERTOTFLUX_G','FIBERTOTFLUX_R','FIBERTOTFLUX_Z']\n",
     "print(final_cols)"
    ]
   },
@@ -231,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "a6ca8bce-8476-4b62-bd9f-2f791e17de69",
    "metadata": {},
    "outputs": [],
@@ -243,6 +262,13 @@
     "    keep = (T['COADD_FIBERSTATUS']==0)\n",
     "    return T[keep]\n",
     "\n",
+    "def cut_npixels(T):\n",
+    "    ''' \n",
+    "    keep only objects with 'NPIXELS' > 0 (signifying they have a coadded spectrum)\n",
+    "    '''\n",
+    "    keep = (T['NPIXELS']>0)\n",
+    "    return T[keep]\n",
+    "\n",
     "# def cut_zwarn(T):\n",
     "#     ''' \n",
     "#     keep only objects with \n",
@@ -250,12 +276,12 @@
     "#     keep = (T['']==)\n",
     "#     return T[keep]\n",
     "\n",
-    "# def cut_objtype(T):\n",
-    "#     ''' \n",
-    "#     keep only objects with \n",
-    "#     '''\n",
-    "#     keep = (T['']==)\n",
-    "#     return T[keep]\n",
+    "def cut_objtype(T):\n",
+    "    ''' \n",
+    "    keep only objects with 'OBJTYPE' == 'TGT'\n",
+    "    '''\n",
+    "    keep = (T['OBJTYPE']=='TGT')\n",
+    "    return T[keep]\n",
     "\n",
     "# def cut_lowz_star(T):\n",
     "#     ''' \n",
@@ -344,7 +370,15 @@
     }
    ],
    "source": [
-    "qsom_cols=['TARGETID','Z','ZERR','ZWARN','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC','MORPHTYPE','EBV','MASKBITS','DESI_TARGET','SCND_TARGET','COADD_NUMEXP','COADD_EXPTIME','CMX_TARGET','SV1_DESI_TARGET','SV2_DESI_TARGET','SV3_DESI_TARGET','SV1_SCND_TARGET','SV2_SCND_TARGET','SV3_SCND_TARGET','TSNR2_LYA','TSNR2_QSO','DELTA_CHI2_MGII','A_MGII','SIGMA_MGII','B_MGII','VAR_A_MGII','VAR_SIGMA_MGII','VAR_B_MGII','Z_RR','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','Z_LYA','Z_CIV','Z_CIII','Z_MgII','Z_Hbeta','Z_Halpha','QSO_MASKBITS','HPXPIXEL','SURVEY','PROGRAM']\n",
+    "## SJ: will exclude the targeting cols because we'll add them from the zcat VAC instead \n",
+    "##    (+ deleting HPXPIXEL as it's the old name; will get HEALPIX instead)\n",
+    "#qsom_cols=['TARGETID','Z','ZERR','ZWARN','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC','MORPHTYPE','EBV','MASKBITS','DESI_TARGET','SCND_TARGET','COADD_NUMEXP','COADD_EXPTIME','CMX_TARGET','SV1_DESI_TARGET','SV2_DESI_TARGET','SV3_DESI_TARGET','SV1_SCND_TARGET','SV2_SCND_TARGET','SV3_SCND_TARGET','TSNR2_LYA','TSNR2_QSO','DELTA_CHI2_MGII','A_MGII','SIGMA_MGII','B_MGII','VAR_A_MGII','VAR_SIGMA_MGII','VAR_B_MGII','Z_RR','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','Z_LYA','Z_CIV','Z_CIII','Z_MgII','Z_Hbeta','Z_Halpha','QSO_MASKBITS','HPXPIXEL','SURVEY','PROGRAM']\n",
+    "qsom_cols=['TARGETID','Z','ZERR','ZWARN','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC','MORPHTYPE','EBV','MASKBITS',\\\n",
+    "           'COADD_NUMEXP','COADD_EXPTIME','TSNR2_LYA','TSNR2_QSO',\\\n",
+    "           'DELTA_CHI2_MGII','A_MGII','SIGMA_MGII','B_MGII','VAR_A_MGII','VAR_SIGMA_MGII','VAR_B_MGII',\\\n",
+    "           'Z_RR','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','Z_LYA','Z_CIV','Z_CIII','Z_MgII','Z_Hbeta','Z_Halpha',\\\n",
+    "           'QSO_MASKBITS','SURVEY','PROGRAM']\n",
+    "\n",
     "print(qsom_cols)"
    ]
   },
@@ -373,8 +407,15 @@
     }
    ],
    "source": [
-    "#cutting on fibrestatus\n",
-    "T_qsom_cut = cut_fiberstatus(T_qsom)\n",
+    "# Cutting on objtype\n",
+    "T_qsom_cut = cut_objtype(T_qsom)\n",
+    "\n",
+    "# Cutting on fiberstatus (replacing this with NPIXELS cut)\n",
+    "#T_qsom_cut = cut_fiberstatus(T_qsom) #<-- need to replace T_qsom with T_qsom_cut if already cut on something\n",
+    "\n",
+    "# Cutting on NPIXELS (set to 0 when the spectrum was not coadded due to bad fiberstatus values)\n",
+    "T_qsom_cut = cut_npixels(T_qsom_cut)\n",
+    "\n",
     "print(len(T_qsom_cut))"
    ]
   },
@@ -402,19 +443,25 @@
    "id": "578af092-4367-474d-b4a9-3f8e2d8e853c",
    "metadata": {},
    "source": [
-    "## 2. Add corect redshifts\n",
+    "## 2. Use the Redshift Summary (zcat) VAC\n",
     "\n",
-    "change tagetting columns"
+    "The Redshift Summary Catalog VAC supersedes the original redshift catalogs for Fuji (EDR) as described [here](https://data.desi.lbl.gov/doc/releases/edr/vac/zcat/).\n",
+    "\n",
+    "- Question: do we want to add the MJD info (min, max, mean)?"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "7d61c5cf-2386-4ccc-9671-62e6a0c40c26",
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a6685339-54b9-48d0-b7e7-e8cde7a6727c",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## 2. Zpix Summary Cat with primary flag\n",
-    "\n",
-    "This function is used to add columns useful for the primary spectra identification"
+    "## SJ: I was starting to read separately the zcat VAC but I think we can delete this and replace the \n",
+    "## part with the (now superseded) summary catalog as all the same columns are available -- and more!\n",
+    "#\n",
+    "#file_zcat_vac = '/global/cfs/cdirs/desi/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits'\n",
+    "#zcat_vac = Table.read(file_zcat_vac)"
    ]
   },
   {
@@ -424,31 +471,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file_zpix_sum_cat=dir_for_tmp+'zpix-'+specprod+'-summary.fits'"
+    "#file_zpix_sum_cat=dir_for_tmp+'zpix-'+specprod+'-summary.fits'\n",
+    "# Using the public EDR version of the zcat VAC\n",
+    "file_zpix_sum_cat = '/global/cfs/cdirs/desi/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "80e9da43-d15b-4004-9d9b-a92824ff3b29",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "zpix summary file exists - using existing copy\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# from https://github.com/desihub/desispec/blob/master/py/desispec/zcatalog.py\n",
     "# for fugi 2Gb file (approx 5 mins)\n",
-    "if os.path.isfile(file_zpix_sum_cat):\n",
-    "    print('zpix summary file exists - using existing copy')\n",
-    "else:\n",
-    "    print('Creating zpix summery file - may take 5 mins')\n",
-    "    create_summary_catalog(specprod, specgroup = specgroup_type, all_columns = True, columns_list = None, output_filename = file_zpix_sum_cat)"
+    "#if os.path.isfile(file_zpix_sum_cat):\n",
+    "#    print('zpix summary file exists - using existing copy')\n",
+    "#else:\n",
+    "#    print('Creating zpix summery file - may take 5 mins')\n",
+    "#    create_summary_catalog(specprod, specgroup = specgroup_type, all_columns = True, columns_list = None, output_filename = file_zpix_sum_cat)"
    ]
   },
   {
@@ -468,9 +509,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "need_cols = ['TARGETID','SURVEY','PROGRAM','TSNR2_LRG','SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY'] # fuji\n",
-    "#need_cols = ['TARGETID','SURVEY','PROGRAM','TSNR2_LRG','ZCAT_NSPEC','ZCAT_PRIMARY'] # guadalupe\n",
-    "T_zpixsum_cut = T_zpixsum[need_cols]\n",
+    "need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','TSNR2_LRG','SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY','NPIXELS'] # fuji\n",
+    "#need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','TSNR2_LRG','ZCAT_NSPEC','ZCAT_PRIMARY','NPIXELS'] # guadalupe\n",
+    "\n",
+    "# Replace targeting columns with updated version from zcat VAC (for Fuji), keeping BGS to find BGS_WISE targets\n",
+    "target_cols = ['DESI_TARGET','BGS_TARGET','SCND_TARGET','CMX_TARGET','SV1_DESI_TARGET','SV1_BGS_TARGET','SV1_SCND_TARGET',\\\n",
+    "              'SV2_DESI_TARGET','SV2_BGS_TARGET','SV2_SCND_TARGET','SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_SCND_TARGET']\n",
+    "\n",
+    "T_zpixsum_cut = T_zpixsum[need_cols+target_cols]\n",
     "T_qsom_zpixsum = join(T_qsom_cut, T_zpixsum_cut, keys=keys_for_join, join_type='left')"
    ]
   },
@@ -489,7 +535,7 @@
     }
    ],
    "source": [
-    "# making sure this is the sane size as before\n",
+    "# making sure this is the same size as before\n",
     "print(len(T_qsom_zpixsum))"
    ]
   },
@@ -720,7 +766,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#T=T[final_cols]"
+    "# T = T[final_cols]"
    ]
   },
   {
@@ -730,16 +776,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "T.write(dir_for_cat+'agnqso_sum_v1.0.2fits', format='fits', overwrite=True)"
+    "## Might need to update name here?!\n",
+    "T.write(dir_for_cat+'agnqso_sum_v1.0.fits', format='fits', overwrite=True)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "94f492ca-5e5d-490d-bec9-dfe82b6a049b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -752,9 +791,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DESI master",
+   "display_name": "DESI 23.1",
    "language": "python",
-   "name": "desi-master"
+   "name": "desi_23.1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -766,7 +805,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Left some traces of the changes commented out with reasons in the comments. I think it's simpler to replace the use of the zcat summary with the new zcat VAC because it supersedes it and includes all the same columns with additional ones.

I applied two cuts: OBJTYPE=TGT and NPIXELS>0 which I think are a good starting point.

I wasn't able to test it because Perlmutter Jupyter NB server was down (again!).