### PR TITLE
fixed IR diag, masks, catalog and nb

### DIFF
--- a/AgnCats/notebooks/AGNQSO_summary_cat.ipynb
+++ b/AgnCats/notebooks/AGNQSO_summary_cat.ipynb
@@ -409,8 +409,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10 s, sys: 3.85 s, total: 13.8 s\n",
-      "Wall time: 14 s\n"
+      "CPU times: user 11.1 s, sys: 4.19 s, total: 15.3 s\n",
+      "Wall time: 15.4 s\n"
      ]
     }
    ],
@@ -857,10 +857,10 @@
        "  - [QN_VAR_WISE,      7, \"Quasar Net reclassifies VAR_WISE_QSO target as a QSO\"]\n",
        "  - [BPT_ANY_SY,      10, \"At least one BPT diagnostic indicates SEYFERT (robust AGN)\"]\n",
        "  - [BPT_ANY_AGN,     11, \"At least one BPT diagnostic indicates SEYFERT, LINER or COMPOSITE\"]\n",
-       "  - [BROAD_LINE,      12, \"Lines with FWHN >=1200 km/s in Halpha, Hbeta, MgII and/or CIV line\"]\n",
+       "  - [BROAD_LINE,      12, \"Lines with FWHM >=1200 km/s in Halpha, Hbeta, MgII and/or CIV line\"]\n",
        "  - [OPT_OTHER_AGN,   13, \"Rest frame optical emission lines diagnostic not BPT (4000-10000 ang) indicate AGN\"]\n",
        "  - [UV,              14, \"Rest frame UV emission lines indicate AGN\"]\n",
-       "  - [WISE_ANY_AGN,    15, \"At least one Infrared (WISE) colour diagnostic indicate AGN\"]\n",
+       "  - [WISE_ANY_AGN,    15, \"At least one infrared (WISE) colour diagnostic indicates AGN\"]\n",
        "  - [XRAY,            16, \"X-rays indicate AGN (not yet implemented)\"]\n",
        "  - [RADIO,           17, \"Radio indicates AGN (not yet implemented)\"]"
       ]
@@ -886,7 +886,7 @@
      "data": {
       "text/plain": [
        "OPT_UV_TYPE:\n",
-       "  - [NII_BPT,          0, \"NII BPT diagnostic is avalible (update_AGNTYPE_NIIBPT)\"]\n",
+       "  - [NII_BPT,          0, \"NII BPT diagnostic is available (update_AGNTYPE_NIIBPT)\"]\n",
        "  - [NII_SF,           1, \"NII BPT Star-forming (update_AGNTYPE_NIIBPT)\"]\n",
        "  - [NII_COMP,         2, \"NII BPT Composite (update_AGNTYPE_NIIBPT)\"]\n",
        "  - [NII_SY,           3, \"NII BPT Seyfert (update_AGNTYPE_NIIBPT)\"]\n",
@@ -1071,7 +1071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 34,
    "id": "9fada6e4-e18a-43e0-a051-62b893277c56",
    "metadata": {
     "tags": []
@@ -1083,7 +1083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 35,
    "id": "3d89babf-0f16-4e5f-9e1c-45f5cb1a961c",
    "metadata": {
     "tags": []
@@ -1106,7 +1106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 36,
    "id": "50363def-681b-4373-bf63-fa8b75dcfbb4",
    "metadata": {
     "tags": []
@@ -1140,7 +1140,7 @@
       "391563994627\n",
       "391563994723\n",
       "391689823843\n",
-      "Length = 3895 rows\n"
+      "Length = 3656 rows\n"
      ]
     }
    ],
@@ -1150,7 +1150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 37,
    "id": "bbb59b05-dfbc-43c6-a268-11c2535c4356",
    "metadata": {
     "tags": []
@@ -1162,7 +1162,7 @@
        "155350"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1175,7 +1175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 38,
    "id": "68df9841-8b65-470f-8033-5f13b029a783",
    "metadata": {
     "tags": []
@@ -1187,7 +1187,7 @@
        "<TableColumns names=('TARGETID','Z','ZERR','ZWARN','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC','MORPHTYPE','MASKBITS','COADD_NUMEXP','COADD_EXPTIME','TSNR2_LYA','TSNR2_QSO','DELTA_CHI2_MGII','A_MGII','SIGMA_MGII','B_MGII','VAR_A_MGII','VAR_SIGMA_MGII','VAR_B_MGII','Z_RR','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','Z_LYA','Z_CIV','Z_CIII','Z_MgII','Z_Hbeta','Z_Halpha','QSO_MASKBITS','SURVEY','PROGRAM','HEALPIX','TSNR2_LRG','SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY','MIN_MJD','MEAN_MJD','MAX_MJD','OBJTYPE','DESI_TARGET','BGS_TARGET','SCND_TARGET','CMX_TARGET','SV1_DESI_TARGET','SV1_BGS_TARGET','SV1_SCND_TARGET','SV2_DESI_TARGET','SV2_BGS_TARGET','SV2_SCND_TARGET','SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_SCND_TARGET','QN_C_LINE_BEST','QN_C_LINE_SECOND_BEST','PHOTSYS','LS_ID','FIBERFLUX_G','FIBERFLUX_R','FIBERFLUX_Z','FIBERTOTFLUX_G','FIBERTOTFLUX_R','FIBERTOTFLUX_Z','FLUX_G','FLUX_R','FLUX_Z','FLUX_W1','FLUX_W2','FLUX_W3','FLUX_W4','FLUX_IVAR_G','FLUX_IVAR_R','FLUX_IVAR_Z','FLUX_IVAR_W1','FLUX_IVAR_W2','FLUX_IVAR_W3','FLUX_IVAR_W4','EBV','MW_TRANSMISSION_G','MW_TRANSMISSION_R','MW_TRANSMISSION_Z','MW_TRANSMISSION_W1','MW_TRANSMISSION_W2','MW_TRANSMISSION_W3','MW_TRANSMISSION_W4','LOGMSTAR','CIV_1549_FLUX','CIV_1549_FLUX_IVAR','CIV_1549_VSHIFT','CIV_1549_SIGMA','MGII_2796_FLUX','MGII_2796_FLUX_IVAR','MGII_2796_VSHIFT','MGII_2796_SIGMA','MGII_2803_FLUX','MGII_2803_FLUX_IVAR','MGII_2803_SIGMA','OII_3726_FLUX','OII_3726_FLUX_IVAR','OII_3726_EW','OII_3726_EW_IVAR','OII_3729_FLUX','OII_3729_FLUX_IVAR','OII_3729_EW','OII_3729_EW_IVAR','NEV_3426_FLUX','NEV_3426_FLUX_IVAR','NEV_3426_VSHIFT','NEV_3426_SIGMA','HEII_4686_FLUX','HEII_4686_FLUX_IVAR','HBETA_EW','HBETA_EW_IVAR','HBETA_FLUX','HBETA_FLUX_IVAR','HBETA_VSHIFT','HBETA_SIGMA','HBETA_BROAD_FLUX','HBETA_BROAD_FLUX_IVAR','HBETA_BROAD_VSHIFT','HBETA_BROAD_SIGMA','HBETA_BROAD_CHI2','OIII_5007_FLUX','OIII_5007_FLUX_IVAR','OIII_5007_VSHIFT','OIII_5007_SIGMA','OI_6300_FLUX','OI_6300_FLUX_IVAR','OI_6300_VSHIFT','OI_6300_SIGMA','HALPHA_EW','HALPHA_FLUX','HALPHA_FLUX_IVAR','HALPHA_VSHIFT','HALPHA_SIGMA','HALPHA_BROAD_FLUX','HALPHA_BROAD_FLUX_IVAR','HALPHA_BROAD_VSHIFT','HALPHA_BROAD_SIGMA','NII_6584_FLUX','NII_6584_FLUX_IVAR','NII_6584_VSHIFT','NII_6584_SIGMA','SII_6716_FLUX','SII_6716_FLUX_IVAR','SII_6716_VSHIFT','SII_6716_SIGMA','SII_6731_FLUX','SII_6731_FLUX_IVAR','SII_6731_VSHIFT','SII_6731_SIGMA','AGN_MASKBITS','OPT_UV_TYPE','IR_TYPE')>"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1228,7 +1228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 40,
    "id": "ed6c20ac-ddcd-4d44-a96a-d9dd05deacc0",
    "metadata": {
     "tags": []
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 41,
    "id": "e902c4fa-26fe-476d-8f32-eb54ce180a2e",
    "metadata": {
     "tags": []
@@ -1288,8 +1288,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 12.2 s, sys: 1.52 s, total: 13.7 s\n",
-      "Wall time: 14 s\n"
+      "CPU times: user 12.6 s, sys: 1.56 s, total: 14.1 s\n",
+      "Wall time: 14.4 s\n"
      ]
     }
    ],
@@ -1301,7 +1301,7 @@
     "table1_hdu = fits.BinTableHDU(T_final_cols)\n",
     "table2_hdu = fits.BinTableHDU(T_sec_ext)\n",
     "hdulist = fits.HDUList([primary_hdu, table1_hdu, table2_hdu])\n",
-    "hdulist.writeto(dir_for_cat+'agnqso_sum_v1.7.fits', overwrite=False)"
+    "hdulist.writeto(dir_for_cat+'agnqso_sum_v1.8.fits', overwrite=False)"
    ]
   },
   {

--- a/AgnCats/py/AGNdiagnosticsFunctionsDESI.py
+++ b/AgnCats/py/AGNdiagnosticsFunctionsDESI.py
@@ -1,8 +1,8 @@
 import numpy as np
 
 '''notes for us:
-Find/replace: Mar_&_Steph_2023 with correct reference 
-Find/replace: Summary_ref_2023 with correct reference
+Find/replace: Mar_&_Steph_2025 with correct reference 
+Find/replace: Summary_ref_2025 with correct reference
 Find/replace: FastSpecFit_ref with correct reference
 '''
 
@@ -385,10 +385,10 @@ def OI_BPT(input, snr=3, snrOI=1, Kewley01=False, mask=None):
 
 def WHAN(input, snr=3, mask=None):
     '''
-    If using these diagnostic fuctions please ref Mar_&_Steph_2023
+    If using these diagnostic fuctions please ref Mar_&_Steph_2025
     and the appropriate references given below.
     
-    If using DESI please reference Summary_ref_2023 and the apprpriate
+    If using DESI please reference Summary_ref_2025 and the apprpriate
     emission line catalog (e.g. FastSpecFit ref FastSpecFit_ref)
 
     --original diagram WHAN diagram (Cid Fernandes et al. 2011)--
@@ -597,7 +597,8 @@ def MEX(input, snr=3, mask=None):
     # MEX intermediate
     mex_interm = (x>9.6)&(y>=a0+a1*x+a2*x**2+a3*x**3)&(~mex_agn)
     
-    return (mex, mex_agn, mex_sf, mex_interm)
+    # Return whether it's available and then the 3 classes when also available
+    return (mex, mex&mex_agn, mex&mex_sf, mex&mex_interm)
     
 ##########################################################################################################
 ##########################################################################################################
@@ -655,17 +656,18 @@ def KEX(input, snr=3, mask=None):
     # KEX intermediate
     kex_interm= (y>=-2.*x+4.2) & (y<3.) & (~kex_agn)
     
-    return (kex, kex_agn, kex_sf, kex_interm)
+    # Return whether it's available and then the 3 classes when also available
+    return (kex, kex&kex_agn, kex&kex_sf, kex&kex_interm)
     
 ##########################################################################################################
 ##########################################################################################################
 
 def HeII_BPT(input, snr=3, mask=None):
     '''
-    If using these diagnostic fuctions please ref Mar_&_Steph_2023
+    If using these diagnostic fuctions please ref Mar_&_Steph_2025
     and the appropriate references given below.
     
-    If using DESI please reference Summary_ref_2023 and the apprpriate
+    If using DESI please reference Summary_ref_2025 and the apprpriate
     emission line catalog (e.g. FastSpecFit ref FastSpecFit_ref)
 
     --original diagram BPT DIAGRAM Shirazi & Brinchmann 2012--
@@ -727,10 +729,10 @@ def HeII_BPT(input, snr=3, mask=None):
 
 def NeV(input, snr=2.5, mask=None):
     '''
-    If using these diagnostic fuctions please ref Mar_&_Steph_2023
+    If using these diagnostic fuctions please ref Mar_&_Steph_2025
     and the appropriate references given below.
     
-    If using DESI please reference Summary_ref_2023 and the apprpriate
+    If using DESI please reference Summary_ref_2025 and the apprpriate
     emission line catalog (e.g. FastSpecFit ref FastSpecFit_ref)
 
     --NeV diagnostic--
@@ -778,7 +780,7 @@ def WISE_colors(input, snr=3, mask=None, diag='All', weak_agn=False):
     If using these diagnostic fuctions please ref Mar_&_Steph_2025
     and the appropriate references given below.
     
-    If using DESI please reference Summary_ref_2023 and the apprpriate
+    If using DESI please reference Summary_ref_2025 and the apprpriate
     photometry catalog (e.g., Tractor or Photometry VAC)
 
     --WISE Color diagnostic--

--- a/AgnCats/py/set_agn_masksDESI.py
+++ b/AgnCats/py/set_agn_masksDESI.py
@@ -427,9 +427,9 @@ def update_AGNTYPE_WISE_colors(T, IR_TYPE, snr=3, mask=None):
         
 
     # If W1, W2 fluxes are above threshold snr (required for Stern+ and Assef+)
-    agn_mask = wise_w12 * IR_TYPE.WISE_W12
+    agn_mask |= wise_w12 * IR_TYPE.WISE_W12
     # If W1, W2, W3 fluxes are above threshold snr (required for Jarrett+, Mateos+, Yao+, Hviding+)
-    agn_mask = wise_w123 * IR_TYPE.WISE_W123
+    agn_mask |= wise_w123 * IR_TYPE.WISE_W123
 
     # Turn into a table column
     agnmask_column = Column(agn_mask, name = 'IR_TYPE')


### PR DESCRIPTION
Fixed code for diagnostics (MEx, KEx) and setting up the IR diagnostic masks (IR_TYPE). Using those fixes, ran catalog v1.8 for EDR and re-ran the test_IR_diagnostics notebook (where I fixed one bug for w1w2_only). 