### PR TITLE
Remake dr1

### DIFF
--- a/AgnCats/notebooks/00_AGNQSO_summary_cat.ipynb
+++ b/AgnCats/notebooks/00_AGNQSO_summary_cat.ipynb
@@ -1741,9 +1741,6 @@
    "outputs": [],
    "source": [
     "## Choose thresholds for S/N cuts on certain lines or quantities\n",
-    "\n",
-    "## TO DO: UPDATE THE DEFAULT VALUES TO 3 ALSO IN THE DIAGNOSTIC FUNCTIONS\n",
-    "\n",
     "snr_default = 3.0\n",
     "snr_oi_default = 3.0\n",
     "snr_oii_default = 3.0\n",

--- a/AgnCats/notebooks/00_AGNQSO_summary_cat.ipynb
+++ b/AgnCats/notebooks/00_AGNQSO_summary_cat.ipynb
@@ -48,6 +48,7 @@
    "source": [
     "# General imports\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
     "import os.path\n",
@@ -498,6 +499,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "168ebdc2-b5ca-4825-a85e-7800e142f938",
+   "metadata": {},
+   "source": [
+    "### Original: Astropy Tables -> hstack"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "820ec229-d716-40f3-85b6-0ce8aaf31b59",
@@ -507,8 +516,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.19 s, sys: 3.89 s, total: 7.08 s\n",
-      "Wall time: 18 s\n"
+      "CPU times: user 4.36 s, sys: 13.9 s, total: 18.2 s\n",
+      "Wall time: 4min 18s\n"
      ]
     }
    ],
@@ -530,8 +539,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 64.7 ms, sys: 201 ms, total: 266 ms\n",
-      "Wall time: 264 ms\n"
+      "CPU times: user 35.5 ms, sys: 77.7 ms, total: 113 ms\n",
+      "Wall time: 111 ms\n"
      ]
     }
    ],
@@ -544,27 +553,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "480c1e4d-b430-4955-8fc9-47e2b52bc3db",
+   "id": "f9e2d153-47e1-4410-b09b-f0443cb7b3f7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#T_fsf.remove_columns(['TARGETID_2','SURVEY_2','PROGRAM_2'])"
+    "## Test to compare catalog length (manually)\n",
+    "#from astropy.io import fits\n",
+    "#fits.info(fastspec_file)     # 1,397,603 Rows (EDR)\n",
+    "#fits.info(file_qsom)         # 2,847,435 Rows (EDR)\n",
+    "#fits.info(file_zpix_sum_cat) # 2,451,325 Rows (EDR)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "776e8ccf-cc97-4a3f-aac6-0c93a6cc6e42",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#T_fsf.rename_columns(['TARGETID_1','SURVEY_1','PROGRAM_1'],\\\n",
-    "#                         ['TARGETID','SURVEY','PROGRAM'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
    "id": "16bcbd29-1747-42a8-adf0-387b7145e94d",
    "metadata": {},
    "outputs": [
@@ -574,7 +576,7 @@
        "0"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -584,6 +586,79 @@
     "del fsf_m\n",
     "del fsf_t\n",
     "gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "29edae53-3d84-4fd4-8054-dbb66c66f18c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=1397603</i>\n",
+       "<table id=\"table139853009167952\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>TARGETID</th><th>SURVEY</th><th>PROGRAM</th><th>LOGMSTAR</th><th>CIV_1549_FLUX</th><th>CIV_1549_FLUX_IVAR</th><th>CIV_1549_SIGMA</th><th>MGII_2796_FLUX</th><th>MGII_2796_FLUX_IVAR</th><th>MGII_2796_SIGMA</th><th>MGII_2803_FLUX</th><th>MGII_2803_FLUX_IVAR</th><th>MGII_2803_SIGMA</th><th>NEV_3426_FLUX</th><th>NEV_3426_FLUX_IVAR</th><th>OII_3726_FLUX</th><th>OII_3726_FLUX_IVAR</th><th>OII_3726_EW</th><th>OII_3726_EW_IVAR</th><th>OII_3729_FLUX</th><th>OII_3729_FLUX_IVAR</th><th>OII_3729_EW</th><th>OII_3729_EW_IVAR</th><th>HEII_4686_FLUX</th><th>HEII_4686_FLUX_IVAR</th><th>HBETA_FLUX</th><th>HBETA_FLUX_IVAR</th><th>HBETA_EW</th><th>HBETA_EW_IVAR</th><th>HBETA_BROAD_FLUX</th><th>HBETA_BROAD_FLUX_IVAR</th><th>HBETA_BROAD_SIGMA</th><th>HBETA_BROAD_CHI2</th><th>OIII_5007_FLUX</th><th>OIII_5007_FLUX_IVAR</th><th>OIII_5007_SIGMA</th><th>OI_6300_FLUX</th><th>OI_6300_FLUX_IVAR</th><th>HALPHA_FLUX</th><th>HALPHA_FLUX_IVAR</th><th>HALPHA_EW</th><th>HALPHA_EW_IVAR</th><th>HALPHA_BROAD_FLUX</th><th>HALPHA_BROAD_FLUX_IVAR</th><th>HALPHA_BROAD_VSHIFT</th><th>HALPHA_BROAD_SIGMA</th><th>NII_6584_FLUX</th><th>NII_6584_FLUX_IVAR</th><th>SII_6716_FLUX</th><th>SII_6716_FLUX_IVAR</th><th>SII_6731_FLUX</th><th>SII_6731_FLUX_IVAR</th><th>Z</th><th>ZWARN</th><th>DELTACHI2</th><th>SPECTYPE</th><th>Z_RR</th><th>PHOTSYS</th><th>LS_ID</th><th>FLUX_W1</th><th>FLUX_W2</th><th>FLUX_W3</th><th>FLUX_IVAR_W1</th><th>FLUX_IVAR_W2</th><th>FLUX_IVAR_W3</th><th>EBV</th><th>MW_TRANSMISSION_W1</th><th>MW_TRANSMISSION_W2</th><th>MW_TRANSMISSION_W3</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>str7</th><th>str6</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th><th>int64</th><th>float64</th><th>str6</th><th>float64</th><th>str1</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
+       "<tr><td>6448025174016</td><td>sv1</td><td>dark</td><td>5.599689</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.207667</td><td>0.7715051</td><td>12.637119</td><td>0.012325867</td><td>1.7035086</td><td>0.81847095</td><td>6.7112455</td><td>0.032602355</td><td>0.23363951</td><td>7.12369</td><td>1.4626874</td><td>9.650367</td><td>5.250497</td><td>0.5623618</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.0653974</td><td>9.83778</td><td>26.742447</td><td>0.2108098</td><td>24.551807</td><td>4.619172</td><td>27.473299</td><td>25.507624</td><td>0.076153</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.17415522</td><td>27.895308</td><td>0.7295528</td><td>20.016008</td><td>0.44656986</td><td>22.050251</td><td>0.022190569941649994</td><td>0</td><td>159.24895933177322</td><td>GALAXY</td><td>0.022190569941649994</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.02702388</td><td>0.9954307</td><td>0.99719137</td><td>0.9994003</td></tr>\n",
+       "<tr><td>6515536691200</td><td>sv1</td><td>dark</td><td>7.515767</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.24348228</td><td>0.041136403</td><td>1861.559</td><td>5.301754</td><td>0.04064875</td><td>1861.559</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.6408178</td><td>1.2575179</td><td>3.337212</td><td>0.04604701</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>100.13853</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.5364068034833155</td><td>4</td><td>2.663280975073576</td><td>GALAXY</td><td>0.5364068034833155</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.01879585</td><td>0.99681973</td><td>0.9980457</td><td>0.9995829</td></tr>\n",
+       "<tr><td>6521555517440</td><td>sv1</td><td>dark</td><td>5.3910193</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.2341658</td><td>0.46782103</td><td>-5.48502</td><td>0.01780844</td><td>1.3066664</td><td>0.4660244</td><td>4.685097</td><td>0.02832791</td><td>0.9040468</td><td>4.4270067</td><td>0.6213819</td><td>6.4305325</td><td>6.4234667</td><td>0.03545121</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.20053317</td><td>4.606641</td><td>54.45429</td><td>0.7624382</td><td>5.852557</td><td>1.8667113</td><td>25.558912</td><td>13.227326</td><td>0.10789884</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.627051</td><td>16.401588</td><td>0.21906249</td><td>18.370296</td><td>0.010017642879535897</td><td>0</td><td>35.273709540546406</td><td>GALAXY</td><td>0.010017642879535897</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.010616658</td><td>0.9982024</td><td>0.99889565</td><td>0.9997644</td></tr>\n",
+       "<tr><td>6536638234624</td><td>sv1</td><td>dark</td><td>7.805484</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.5881265</td><td>0.504739</td><td>122.5513</td><td>9.485201e-07</td><td>6.0486813</td><td>0.500317</td><td>57.179882</td><td>0.00019526201</td><td>0.0</td><td>0.0</td><td>2.0062768</td><td>4.179936</td><td>7.5063195</td><td>0.12218019</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.685861</td><td>1.8641906</td><td>90.60073</td><td>0.36639658</td><td>6.5702343</td><td>5.9210873</td><td>12.381063</td><td>16.246782</td><td>0.5891032</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.5307378</td><td>5.912066</td><td>3.4641097</td><td>6.3909593</td><td>0.52440584</td><td>1.9754051</td><td>0.07641158065394126</td><td>0</td><td>241.65000140666962</td><td>GALAXY</td><td>0.07641158065394126</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.019745098</td><td>0.9966594</td><td>0.9979471</td><td>0.9995618</td></tr>\n",
+       "<tr><td>6546033475584</td><td>sv1</td><td>dark</td><td>8.507698</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.13224204</td><td>0.25811446</td><td>1732.4653</td><td>1.0926803</td><td>0.24412498</td><td>1732.4653</td><td>0.6129738</td><td>14.753207</td><td>0.9128682</td><td>1.8899435</td><td>5.0149326</td><td>0.05685886</td><td>0.4591761</td><td>2.6577134</td><td>2.601349</td><td>0.077292696</td><td>0.8362955</td><td>4.7160745</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.0408032337323003</td><td>4</td><td>6.559948198497295</td><td>GALAXY</td><td>1.0408032337323003</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.03343177</td><td>0.9943503</td><td>0.9965266</td><td>0.9992582</td></tr>\n",
+       "<tr><td>28684312379396</td><td>sv1</td><td>other</td><td>10.31878</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.7109833</td><td>0.1450483</td><td>2.8098907</td><td>0.22383393</td><td>1.1089267</td><td>1.4303137</td><td>8.046435</td><td>0.2249186</td><td>3.2465112</td><td>1.3367975</td><td>0.0</td><td>0.0</td><td>0.9055067</td><td>0.337426</td><td>0.123183504</td><td>18.231556</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>5.4480214</td><td>0.41852513</td><td>193.93852</td><td>6.824828</td><td>0.3234847</td><td>6.902518</td><td>0.7423123</td><td>0.8623974</td><td>47.49454</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>10.98356</td><td>0.6630237</td><td>2.5739596</td><td>0.7611422</td><td>1.9992918</td><td>0.83954203</td><td>0.18835998178379842</td><td>0</td><td>4668.606317777187</td><td>GALAXY</td><td>0.18835998178379842</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.080409616</td><td>0.9864654</td><td>0.99166614</td><td>0.99821675</td></tr>\n",
+       "<tr><td>28684316573697</td><td>sv1</td><td>other</td><td>9.897618</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.7625728</td><td>0.1295451</td><td>0.14362755</td><td>3.6513085</td><td>5.623277</td><td>0.12914616</td><td>1.0273296</td><td>3.8445876</td><td>4.0328355</td><td>0.50101227</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.2483988</td><td>0.24712761</td><td>205.18506</td><td>3.4678915</td><td>0.37202397</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.5876255</td><td>0.36674556</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.08079590364163276</td><td>0</td><td>16538.646016502753</td><td>GALAXY</td><td>0.08079590364163276</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.08610489</td><td>0.98551375</td><td>0.9910785</td><td>0.99809057</td></tr>\n",
+       "<tr><td>28688884170754</td><td>sv1</td><td>other</td><td>10.414571</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>10.161699</td><td>0.2570976</td><td>2.293134</td><td>4.9094653</td><td>10.629224</td><td>0.25783324</td><td>2.3924472</td><td>4.9710703</td><td>0.67344385</td><td>0.16700082</td><td>26.185995</td><td>0.38841996</td><td>2.9133568</td><td>28.358349</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>5.4485273</td><td>0.37861606</td><td>139.09273</td><td>5.1368017</td><td>0.37124717</td><td>107.459595</td><td>0.53130585</td><td>10.574048</td><td>35.091526</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>47.382603</td><td>0.7497844</td><td>22.806305</td><td>0.4913001</td><td>14.423903</td><td>0.7742735</td><td>0.1902043994640309</td><td>0</td><td>10186.361736387014</td><td>GALAXY</td><td>0.1902043994640309</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.07995481</td><td>0.98654145</td><td>0.9917131</td><td>0.9982268</td></tr>\n",
+       "<tr><td>28697990004751</td><td>sv1</td><td>other</td><td>10.5302925</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.011011456</td><td>0.0042387806</td><td>2007.8041</td><td>2.5646415</td><td>0.004522173</td><td>2007.8041</td><td>0.30754167</td><td>0.44755405</td><td>1.668743</td><td>0.8371671</td><td>0.8916866</td><td>2.9196277</td><td>3.2431283</td><td>0.831627</td><td>1.7329535</td><td>2.8701823</td><td>0.0</td><td>0.0</td><td>2.8953023</td><td>0.7712895</td><td>0.7029231</td><td>13.078431</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.4918278</td><td>1.216628</td><td>176.73767</td><td>0.3072921</td><td>1.5873318</td><td>3.2129488</td><td>1.5059292</td><td>0.7575107</td><td>27.071783</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>6.5200186</td><td>2.062333</td><td>6.2614284</td><td>1.0984831</td><td>2.877945</td><td>1.7180064</td><td>0.32793296515141435</td><td>0</td><td>1902.5416062623262</td><td>GALAXY</td><td>0.32793296515141435</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.071104385</td><td>0.9880222</td><td>0.992627</td><td>0.9984229</td></tr>\n",
+       "<tr><td>28702498881536</td><td>sv1</td><td>other</td><td>9.478516</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.0601354</td><td>0.45707437</td><td>21.60714</td><td>0.76626337</td><td>12.413067</td><td>1.1311412</td><td>29.673252</td><td>0.7138484</td><td>17.04696</td><td>1.2183557</td><td>0.2984267</td><td>1.8612021</td><td>16.702677</td><td>1.014768</td><td>6.0473595</td><td>5.6715055</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>15.926442</td><td>1.8070531</td><td>62.802723</td><td>3.6422706</td><td>4.734194</td><td>56.119396</td><td>1.452517</td><td>20.199408</td><td>5.391812</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>25.60015</td><td>2.6601405</td><td>13.32719</td><td>1.158518</td><td>11.392513</td><td>3.1852443</td><td>0.17798538529640778</td><td>0</td><td>6728.577413320541</td><td>GALAXY</td><td>0.17798538529640778</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.05721121</td><td>0.99035126</td><td>0.9940633</td><td>0.9987309</td></tr>\n",
+       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
+       "<tr><td>2305843042134796070</td><td>sv1</td><td>other</td><td>10.340323</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>16.053183</td><td>0.0790929</td><td>0.658221</td><td>46.58613</td><td>8.1409445</td><td>0.07938927</td><td>0.33688965</td><td>46.223366</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.88148</td><td>0.108749144</td><td>249.33252</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>26.687052</td><td>0.197765</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.03878892999156212</td><td>0</td><td>293677.26612750004</td><td>GALAXY</td><td>0.03878892999156212</td><td>S</td><td>9906621854849290</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.050247896</td><td>0.99152064</td><td>0.994784</td><td>0.9988853</td></tr>\n",
+       "<tr><td>2305843042147377573</td><td>sv1</td><td>other</td><td>10.66336</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.3059205</td><td>0.020333856</td><td>314.03915</td><td>0.07568124</td><td>5.55828</td><td>48.297276</td><td>353.7781</td><td>0.06881494</td><td>5.9431524</td><td>74.54678</td><td>0.66239256</td><td>0.18411686</td><td>293.1938</td><td>0.16697626</td><td>4.3317404</td><td>575.846</td><td>161.566</td><td>0.040498827</td><td>716.0994</td><td>1640.3584</td><td>249.39935</td><td>0.108393185</td><td>253.03575</td><td>104.164444</td><td>0.44827002</td><td>1392.686</td><td>0.15750775</td><td>22.859158</td><td>53.012527</td><td>732.07245</td><td>0.057634484</td><td>-83.04449</td><td>716.0994</td><td>998.68604</td><td>0.20084149</td><td>376.08118</td><td>0.3539559</td><td>301.13535</td><td>0.37867835</td><td>0.057023953989562684</td><td>0</td><td>782323.6188697815</td><td>GALAXY</td><td>0.057023953989562684</td><td>S</td><td>9906621949221419</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0510322</td><td>0.99138886</td><td>0.9947028</td><td>0.99886787</td></tr>\n",
+       "<tr><td>2305843042147377905</td><td>sv1</td><td>other</td><td>10.574649</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>9.519037</td><td>0.019183531</td><td>12.236759</td><td>0.08033947</td><td>0.9986014</td><td>12.002107</td><td>10.502899</td><td>0.083187394</td><td>0.8463118</td><td>12.760636</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>9.51022</td><td>0.11632779</td><td>314.439</td><td>11.110644</td><td>0.20063317</td><td>10.903104</td><td>0.27791336</td><td>0.26665533</td><td>464.5722</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>38.796997</td><td>0.19717076</td><td>10.037841</td><td>0.19676279</td><td>0.21927436</td><td>0.16282706</td><td>0.08144121052643025</td><td>0</td><td>83817.33106590807</td><td>GALAXY</td><td>0.08144121052643025</td><td>S</td><td>9908821161548941</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.060582705</td><td>0.98978555</td><td>0.9937146</td><td>0.99865615</td></tr>\n",
+       "<tr><td>2305843042147384986</td><td>sv1</td><td>other</td><td>10.512808</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>28.585022</td><td>0.2748309</td><td>2.031568</td><td>34.32801</td><td>33.639565</td><td>0.27984172</td><td>2.4721737</td><td>34.400505</td><td>0.83233225</td><td>0.36537302</td><td>5.844024</td><td>0.3857219</td><td>0.13378699</td><td>735.09045</td><td>12.769184</td><td>0.04830324</td><td>805.4619</td><td>186.26344</td><td>43.474438</td><td>0.2981298</td><td>122.742325</td><td>16.223097</td><td>0.75823283</td><td>31.990007</td><td>0.74460155</td><td>0.59558797</td><td>2122.569</td><td>76.42866</td><td>0.08429988</td><td>93.845604</td><td>805.4619</td><td>90.675735</td><td>0.64910233</td><td>25.820608</td><td>0.7580176</td><td>24.436249</td><td>0.76803917</td><td>0.05265338266526968</td><td>0</td><td>184894.1936070025</td><td>GALAXY</td><td>0.05265338266526968</td><td>S</td><td>9906621854980040</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.058096286</td><td>0.9902027</td><td>0.99397177</td><td>0.9987113</td></tr>\n",
+       "<tr><td>2305843042147391551</td><td>sv1</td><td>other</td><td>10.378264</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>7.89992</td><td>0.11585758</td><td>43.712505</td><td>0.32280082</td><td>6.9622164</td><td>6.5571733</td><td>43.650646</td><td>0.33877662</td><td>6.8384457</td><td>6.1690474</td><td>2.1191776</td><td>0.5358236</td><td>16.78089</td><td>0.5270962</td><td>0.8335084</td><td>212.28624</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>94.52678</td><td>0.46715292</td><td>139.25536</td><td>21.192663</td><td>1.1455337</td><td>63.979534</td><td>0.95909756</td><td>2.611239</td><td>559.24994</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>131.5333</td><td>0.8744881</td><td>47.54538</td><td>1.0483961</td><td>40.40041</td><td>0.9272278</td><td>0.08172594865904519</td><td>0</td><td>68736.61024258845</td><td>GALAXY</td><td>0.08172594865904519</td><td>S</td><td>9908821350291202</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.040710934</td><td>0.9931244</td><td>0.9957719</td><td>0.99909675</td></tr>\n",
+       "<tr><td>2305843042155798043</td><td>sv1</td><td>other</td><td>9.685999</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>28.61426</td><td>0.19885655</td><td>1.9630638</td><td>24.616365</td><td>30.630573</td><td>0.19766057</td><td>2.0082514</td><td>38.197853</td><td>0.0</td><td>0.0</td><td>1.9862528</td><td>0.3119223</td><td>0.04458466</td><td>619.04755</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>27.753761</td><td>0.4674989</td><td>125.15035</td><td>30.06995</td><td>0.6002575</td><td>23.335228</td><td>0.4577279</td><td>0.4955358</td><td>1011.77527</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>36.96322</td><td>0.70331675</td><td>11.354582</td><td>0.7222276</td><td>9.9280405</td><td>0.712657</td><td>0.0412873115248978</td><td>0</td><td>218643.28112494946</td><td>GALAXY</td><td>0.0412873115248978</td><td>S</td><td>9906622609692242</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.04719524</td><td>0.9920337</td><td>0.99510014</td><td>0.998953</td></tr>\n",
+       "<tr><td>2305843042155799845</td><td>sv1</td><td>other</td><td>10.599554</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>7.793753</td><td>0.09041524</td><td>11.895562</td><td>0.20531094</td><td>1.1461375</td><td>21.484755</td><td>6.0308957</td><td>0.21246873</td><td>0.5723221</td><td>23.435827</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.78955853</td><td>0.35220748</td><td>250.46233</td><td>0.8997545</td><td>0.48671958</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>16.29707</td><td>0.44885594</td><td>0.8542664</td><td>0.495905</td><td>0.03543765</td><td>0.40773296</td><td>0.11093408916418691</td><td>0</td><td>136514.13255812973</td><td>GALAXY</td><td>0.11093408916418691</td><td>S</td><td>9906622515320312</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.044599093</td><td>0.99247026</td><td>0.995369</td><td>0.9990105</td></tr>\n",
+       "<tr><td>2305843042155804385</td><td>sv1</td><td>other</td><td>9.953221</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>37.373234</td><td>0.10042959</td><td>1.411296</td><td>60.3057</td><td>19.313242</td><td>0.09760767</td><td>0.73599195</td><td>65.854065</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>12.846311</td><td>0.17296638</td><td>235.6152</td><td>10.886342</td><td>0.23574018</td><td>13.435347</td><td>0.14429727</td><td>0.1642379</td><td>965.5469</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>53.133587</td><td>0.23602295</td><td>1.9770168</td><td>0.23250842</td><td>0.6920749</td><td>0.23800856</td><td>0.039058800493108496</td><td>0</td><td>437887.4999078214</td><td>GALAXY</td><td>0.039058800493108496</td><td>S</td><td>9906622232073782</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.046971545</td><td>0.99207133</td><td>0.99512327</td><td>0.99895793</td></tr>\n",
+       "<tr><td>2305843042155806193</td><td>sv1</td><td>other</td><td>8.20211</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.333923</td><td>0.06916472</td><td>0.09724557</td><td>81.220436</td><td>35.302326</td><td>0.0645709</td><td>1.0256144</td><td>70.00919</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>255.21448</td><td>1.0706209</td><td>0.20143317</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>45.596195</td><td>0.21852778</td><td>10.445338</td><td>0.23132926</td><td>0.9271886</td><td>0.23209725</td><td>0.006397039963574819</td><td>0</td><td>451167.98290259484</td><td>GALAXY</td><td>0.006397039963574819</td><td>S</td><td>9906622326577270</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.04144449</td><td>0.993001</td><td>0.9956959</td><td>0.9990805</td></tr>\n",
+       "<tr><td>2305843042428400793</td><td>sv1</td><td>dark</td><td>12.436547</td><td>0.0</td><td>0.0</td><td>0.0</td><td>465.98404</td><td>0.031809818</td><td>7620.754</td><td>439.44037</td><td>0.03214867</td><td>7620.754</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.243089</td><td>2.4272156</td><td>37.53033</td><td>1.9327645</td><td>1.8195287</td><td>700.97064</td><td>116.496735</td><td>0.1357949</td><td>3111.0974</td><td>24320.594</td><td>0.0</td><td>0.0</td><td>196.99255</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.6523581021562065</td><td>0</td><td>6781.642284573172</td><td>QSO</td><td>0.6523581021562065</td><td>S</td><td>9906626808644496</td><td>68.676346</td><td>44.80062</td><td>-49.402035</td><td>2.2574499</td><td>0.73553425</td><td>0.00096569414</td><td>0.043133702</td><td>0.9927168</td><td>0.99552083</td><td>0.99904305</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=1397603>\n",
+       "      TARGETID      SURVEY PROGRAM ... MW_TRANSMISSION_W2 MW_TRANSMISSION_W3\n",
+       "       int64         str7    str6  ...      float32            float32      \n",
+       "------------------- ------ ------- ... ------------------ ------------------\n",
+       "      6448025174016    sv1    dark ...         0.99719137          0.9994003\n",
+       "      6515536691200    sv1    dark ...          0.9980457          0.9995829\n",
+       "      6521555517440    sv1    dark ...         0.99889565          0.9997644\n",
+       "      6536638234624    sv1    dark ...          0.9979471          0.9995618\n",
+       "      6546033475584    sv1    dark ...          0.9965266          0.9992582\n",
+       "     28684312379396    sv1   other ...         0.99166614         0.99821675\n",
+       "     28684316573697    sv1   other ...          0.9910785         0.99809057\n",
+       "     28688884170754    sv1   other ...          0.9917131          0.9982268\n",
+       "     28697990004751    sv1   other ...           0.992627          0.9984229\n",
+       "     28702498881536    sv1   other ...          0.9940633          0.9987309\n",
+       "                ...    ...     ... ...                ...                ...\n",
+       "2305843042134796070    sv1   other ...           0.994784          0.9988853\n",
+       "2305843042147377573    sv1   other ...          0.9947028         0.99886787\n",
+       "2305843042147377905    sv1   other ...          0.9937146         0.99865615\n",
+       "2305843042147384986    sv1   other ...         0.99397177          0.9987113\n",
+       "2305843042147391551    sv1   other ...          0.9957719         0.99909675\n",
+       "2305843042155798043    sv1   other ...         0.99510014           0.998953\n",
+       "2305843042155799845    sv1   other ...           0.995369          0.9990105\n",
+       "2305843042155804385    sv1   other ...         0.99512327         0.99895793\n",
+       "2305843042155806193    sv1   other ...          0.9956959          0.9990805\n",
+       "2305843042428400793    sv1    dark ...         0.99552083         0.99904305"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "T_fsf"
    ]
   },
   {
@@ -603,7 +678,7 @@
      "data": {
       "text/html": [
        "<div><i>Table length=4</i>\n",
-       "<table id=\"table139710254734528\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table139853009159168\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>TARGETID</th><th>SURVEY</th><th>PROGRAM</th><th>LOGMSTAR</th><th>CIV_1549_FLUX</th><th>CIV_1549_FLUX_IVAR</th><th>CIV_1549_SIGMA</th><th>MGII_2796_FLUX</th><th>MGII_2796_FLUX_IVAR</th><th>MGII_2796_SIGMA</th><th>MGII_2803_FLUX</th><th>MGII_2803_FLUX_IVAR</th><th>MGII_2803_SIGMA</th><th>NEV_3426_FLUX</th><th>NEV_3426_FLUX_IVAR</th><th>OII_3726_FLUX</th><th>OII_3726_FLUX_IVAR</th><th>OII_3726_EW</th><th>OII_3726_EW_IVAR</th><th>OII_3729_FLUX</th><th>OII_3729_FLUX_IVAR</th><th>OII_3729_EW</th><th>OII_3729_EW_IVAR</th><th>HEII_4686_FLUX</th><th>HEII_4686_FLUX_IVAR</th><th>HBETA_FLUX</th><th>HBETA_FLUX_IVAR</th><th>HBETA_EW</th><th>HBETA_EW_IVAR</th><th>HBETA_BROAD_FLUX</th><th>HBETA_BROAD_FLUX_IVAR</th><th>HBETA_BROAD_SIGMA</th><th>HBETA_BROAD_CHI2</th><th>OIII_5007_FLUX</th><th>OIII_5007_FLUX_IVAR</th><th>OIII_5007_SIGMA</th><th>OI_6300_FLUX</th><th>OI_6300_FLUX_IVAR</th><th>HALPHA_FLUX</th><th>HALPHA_FLUX_IVAR</th><th>HALPHA_EW</th><th>HALPHA_EW_IVAR</th><th>HALPHA_BROAD_FLUX</th><th>HALPHA_BROAD_FLUX_IVAR</th><th>HALPHA_BROAD_VSHIFT</th><th>HALPHA_BROAD_SIGMA</th><th>NII_6584_FLUX</th><th>NII_6584_FLUX_IVAR</th><th>SII_6716_FLUX</th><th>SII_6716_FLUX_IVAR</th><th>SII_6731_FLUX</th><th>SII_6731_FLUX_IVAR</th><th>Z</th><th>ZWARN</th><th>DELTACHI2</th><th>SPECTYPE</th><th>Z_RR</th><th>PHOTSYS</th><th>LS_ID</th><th>FLUX_W1</th><th>FLUX_W2</th><th>FLUX_W3</th><th>FLUX_IVAR_W1</th><th>FLUX_IVAR_W2</th><th>FLUX_IVAR_W3</th><th>EBV</th><th>MW_TRANSMISSION_W1</th><th>MW_TRANSMISSION_W2</th><th>MW_TRANSMISSION_W3</th></tr></thead>\n",
        "<thead><tr><th>int64</th><th>str7</th><th>str6</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th><th>int64</th><th>float64</th><th>str6</th><th>float64</th><th>str1</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
        "<tr><td>6448025174016</td><td>sv1</td><td>dark</td><td>5.599689</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.207667</td><td>0.7715051</td><td>12.637119</td><td>0.012325867</td><td>1.7035086</td><td>0.81847095</td><td>6.7112455</td><td>0.032602355</td><td>0.23363951</td><td>7.12369</td><td>1.4626874</td><td>9.650367</td><td>5.250497</td><td>0.5623618</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.0653974</td><td>9.83778</td><td>26.742447</td><td>0.2108098</td><td>24.551807</td><td>4.619172</td><td>27.473299</td><td>25.507624</td><td>0.076153</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.17415522</td><td>27.895308</td><td>0.7295528</td><td>20.016008</td><td>0.44656986</td><td>22.050251</td><td>0.022190569941649994</td><td>0</td><td>159.24895933177322</td><td>GALAXY</td><td>0.022190569941649994</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.02702388</td><td>0.9954307</td><td>0.99719137</td><td>0.9994003</td></tr>\n",
@@ -638,6 +713,18 @@
   {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "2b18783b-85f0-4afb-80ef-83a7110ae4f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Check that expected cuts are applied already\n",
+    "\n",
+    "#assert len(df_fsf[df_fsf['Z']<=0.001])==0, print(\"Some rows have Z<=0.001; expected zero.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "id": "e1997de4-af25-4d78-8f93-331697c7f9b0",
    "metadata": {},
    "outputs": [],
@@ -652,169 +739,36 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8726ce9f-35e5-4dfe-8b7d-4781b872049c",
+   "id": "e15c6540-ec14-4ca3-b718-8ddc5c6dce92",
    "metadata": {},
    "source": [
-    "## 2. Use the Redshift catalog (zall-pix or zcat VAC for Fuji)\n",
-    "\n",
-    "For Fuji (EDR), the Redshift Summary Catalog VAC supersedes the original redshift catalogs as described [here](https://data.desi.lbl.gov/doc/releases/edr/vac/zcat/). For Iron, we use directly the zall-pix. For Loa, we use the split version into survey-program combinations and with NSIDE1 healpixels for main-bright and main-dark."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "80ea6a3c-ed56-47ef-82c9-ab0a440abee8",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 2.33 s, sys: 1.59 s, total: 3.91 s\n",
-      "Wall time: 4.02 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "if specprod == 'fuji':\n",
-    "    need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','TSNR2_LRG','SV_NSPEC','SV_PRIMARY',\n",
-    "                 'ZCAT_NSPEC','ZCAT_PRIMARY','MIN_MJD','MEAN_MJD','MAX_MJD', 'OBJTYPE'] # fuji\n",
-    "if specprod == 'guadalupe':\n",
-    "    need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','TSNR2_LRG','ZCAT_NSPEC','ZCAT_PRIMARY',\n",
-    "                 'MIN_MJD','MEAN_MJD','MAX_MJD','OBJTYPE'] # guadalupe\n",
-    "    # for guadalupe, iron, etc.: also add MAIN_PRIMARY and MAIN_NSPEC\n",
-    "if specprod == 'iron':\n",
-    "    need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','TSNR2_LRG','ZCAT_NSPEC','ZCAT_PRIMARY',\n",
-    "                 'SV_NSPEC','SV_PRIMARY','MAIN_PRIMARY','MAIN_NSPEC','MIN_MJD','MEAN_MJD','MAX_MJD','OBJTYPE']    \n",
-    "\n",
-    "if specprod == 'loa':\n",
-    "    need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','TSNR2_LRG','ZCAT_NSPEC','ZCAT_PRIMARY',\n",
-    "                 'SV_NSPEC','SV_PRIMARY','MAIN_PRIMARY','MAIN_NSPEC','MIN_MJD','MEAN_MJD','MAX_MJD','OBJTYPE']    \n",
-    "\n",
-    "# Replace targeting columns with updated version from zcat VAC (for Fuji), keeping BGS to find BGS_WISE targets\n",
-    "target_cols = ['DESI_TARGET','BGS_TARGET','SCND_TARGET','CMX_TARGET','SV1_DESI_TARGET','SV1_BGS_TARGET','SV1_SCND_TARGET',\n",
-    "               'SV2_DESI_TARGET','SV2_BGS_TARGET','SV2_SCND_TARGET','SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_SCND_TARGET']\n",
-    "\n",
-    "## SJ: for faster performance, only read the desired columns with fitsio() from the zpix_sum file\n",
-    "T_zpixsum = Table(fitsio.read(file_zpix_sum_cat, columns=need_cols+target_cols, ext=1))\n",
-    "#T_zpixsum = Table(fitsio.read(file_zpix_sum_cat, ext=1))"
+    "## 2. QSO-maker Cat"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "b113ebd9-c07c-4f39-8fcd-e1db8325ee57",
+   "id": "da42166a-da73-42b8-bd04-ae12bc614716",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<TableColumns names=('TARGETID','SURVEY','PROGRAM','HEALPIX','OBJTYPE','CMX_TARGET','DESI_TARGET','BGS_TARGET','SCND_TARGET','SV1_DESI_TARGET','SV1_BGS_TARGET','SV1_SCND_TARGET','SV2_DESI_TARGET','SV2_BGS_TARGET','SV2_SCND_TARGET','SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_SCND_TARGET','TSNR2_LRG','SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY','MIN_MJD','MEAN_MJD','MAX_MJD')>"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "T_zpixsum.columns"
+    "# Fuji\n",
+    "\n",
+    "# Iron\n",
+    "#path_qsom = f'/global/cfs/cdirs/desi/science/gqp/agncatalog/qsomaker/iron/'\n",
+    "#file_qsom = path_qsom+'QSO_cat_iron_healpix_all_targets_v1.fits'\n",
+    "\n",
+    "# Loa\n",
+    "#path_qsom = f'/global/cfs/cdirs/desi/science/gqp/agncatalog/qsomaker/loa/'\n",
+    "#file_qsom = path_qsom+'QSO_cat_loa_sv2_backup_healpix_all_targets_v1.fits' #one example for small survey/program\n",
+    "\n",
+    "#test = Table(fitsio.read(file_qsom, rows=[1,2], ext=1))\n",
+    "#test.colnames"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "deaa0ea8-cb86-44a6-949b-ac3eeaa33b51",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 7.4 s, sys: 661 ms, total: 8.06 s\n",
-      "Wall time: 8.03 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "## This is slow! Would it be faster to work with Pandas DataFrames?\n",
-    "## Takes >2min for Iron/DR1 without indexing tables\n",
-    "T_fsf_zpixsum = join(T_fsf, T_zpixsum, keys=keys_for_join, join_type='left')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "74aee87a-a052-4beb-ab26-bf65b6c47472",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1397603\n",
-      "Same length - all good\n"
-     ]
-    }
-   ],
-   "source": [
-    "# making sure this is the same size as before\n",
-    "print(len(T_fsf_zpixsum))\n",
-    "if len(T_fsf) == len(T_fsf_zpixsum):\n",
-    "    print('Same length - all good')\n",
-    "else:\n",
-    "    print('The joined FastSpecFit and zpix catalog df is not the same size as the FastSpecFit catalog')\n",
-    "    print('Something went wrong!')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "fcb3ab7d-679f-4360-bb32-44a36557a7f4",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# free memory\n",
-    "del T_fsf\n",
-    "del T_zpixsum\n",
-    "gc.collect()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "d4aee53d-f9e7-4870-abc5-aba4039e8b0d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Check that cut on OBJTYPE was already made (shouldn't see an error message)\n",
-    "assert len(T_fsf_zpixsum[T_fsf_zpixsum['OBJTYPE']!='TGT'])==0, print(\"Some rows have OBJTYPE != 'TGT'; expected zero.\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "45c4a57e4cb27c3b",
-   "metadata": {},
-   "source": [
-    "## 3. QSO-maker Cat"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
    "id": "4a139523506e695f",
    "metadata": {},
    "outputs": [
@@ -828,7 +782,14 @@
    ],
    "source": [
     "## SJ: will exclude the targeting cols because we'll add them from the zcat VAC instead \n",
-    "#qsom_cols=['TARGETID','Z','ZERR','ZWARN','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC','MORPHTYPE','EBV','MASKBITS','DESI_TARGET','SCND_TARGET','COADD_NUMEXP','COADD_EXPTIME','CMX_TARGET','SV1_DESI_TARGET','SV2_DESI_TARGET','SV3_DESI_TARGET','SV1_SCND_TARGET','SV2_SCND_TARGET','SV3_SCND_TARGET','TSNR2_LYA','TSNR2_QSO','DELTA_CHI2_MGII','A_MGII','SIGMA_MGII','B_MGII','VAR_A_MGII','VAR_SIGMA_MGII','VAR_B_MGII','Z_RR','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','Z_LYA','Z_CIV','Z_CIII','Z_MgII','Z_Hbeta','Z_Halpha','QSO_MASKBITS','HPXPIXEL','SURVEY','PROGRAM']\n",
+    "#qsom_cols=['TARGETID','Z','ZERR','ZWARN','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC',\n",
+    "#           'MORPHTYPE','EBV','MASKBITS','DESI_TARGET','SCND_TARGET','COADD_NUMEXP',\n",
+    "#           'COADD_EXPTIME','CMX_TARGET','SV1_DESI_TARGET','SV2_DESI_TARGET','SV3_DESI_TARGET',\n",
+    "#           'SV1_SCND_TARGET','SV2_SCND_TARGET','SV3_SCND_TARGET','TSNR2_LYA','TSNR2_QSO',\n",
+    "#           'DELTA_CHI2_MGII','A_MGII','SIGMA_MGII','B_MGII','VAR_A_MGII','VAR_SIGMA_MGII',\n",
+    "#           'VAR_B_MGII','Z_RR','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha',\n",
+    "#           'Z_LYA','Z_CIV','Z_CIII','Z_MgII','Z_Hbeta','Z_Halpha','QSO_MASKBITS',\n",
+    "#           'HPXPIXEL','SURVEY','PROGRAM']\n",
     "\n",
     "# Current choice for Iron\n",
     "qsom_cols=['TARGETID','Z','ZERR','SPECTYPE','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC',\n",
@@ -850,16 +811,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "32699160db04e61c",
+   "execution_count": 19,
+   "id": "10decbe5-4bfd-49ee-aa0f-7f922c396b45",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.85 s, sys: 3 s, total: 10.9 s\n",
-      "Wall time: 11 s\n"
+      "CPU times: user 9.64 s, sys: 11 s, total: 20.7 s\n",
+      "Wall time: 1min 41s\n"
      ]
     }
    ],
@@ -872,29 +833,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "53ed96e6-f35d-473d-bb69-8261a56e3acd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Fuji\n",
-    "\n",
-    "# Iron\n",
-    "#path_qsom = f'/global/cfs/cdirs/desi/science/gqp/agncatalog/qsomaker/iron/'\n",
-    "#file_qsom = path_qsom+'QSO_cat_iron_healpix_all_targets_v1.fits'\n",
-    "\n",
-    "# Loa\n",
-    "#path_qsom = f'/global/cfs/cdirs/desi/science/gqp/agncatalog/qsomaker/loa/'\n",
-    "#file_qsom = path_qsom+'QSO_cat_loa_sv2_backup_healpix_all_targets_v1.fits' #one example for small survey/program\n",
-    "\n",
-    "#test = Table(fitsio.read(file_qsom, rows=[1,2], ext=1))\n",
-    "#test.colnames"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "f7ea444b-0728-4dee-becc-a865ea2e70f2",
+   "execution_count": 20,
+   "id": "baf30bfd-8fda-4ff0-a781-72deadd3d228",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,15 +847,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "b4b743efa3675f79",
+   "execution_count": 21,
+   "id": "16cc8e4f-a792-4adb-813e-247786190790",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div><i>Table length=4</i>\n",
-       "<table id=\"table139710254732272\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table139853002180544\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>TARGETID</th><th>Z</th><th>ZERR</th><th>SPECTYPE</th><th>COADD_FIBERSTATUS</th><th>TARGET_RA</th><th>TARGET_DEC</th><th>MORPHTYPE</th><th>MASKBITS</th><th>COADD_NUMEXP</th><th>COADD_EXPTIME</th><th>TSNR2_LYA</th><th>TSNR2_QSO</th><th>Z_QN</th><th>C_LYA</th><th>C_CIV</th><th>C_CIII</th><th>C_MgII</th><th>C_Hbeta</th><th>C_Halpha</th><th>QSO_MASKBITS</th><th>SURVEY</th><th>PROGRAM</th><th>QN_C_LINE_BEST</th></tr></thead>\n",
        "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>str6</th><th>int32</th><th>float64</th><th>float64</th><th>str4</th><th>int16</th><th>int16</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int32</th><th>str7</th><th>str6</th><th>float32</th></tr></thead>\n",
        "<tr><td>39628295930645368</td><td>0.9294714305581361</td><td>4.298046872929627e-05</td><td>GALAXY</td><td>0</td><td>200.28970103825242</td><td>21.48663603561397</td><td>REX</td><td>0</td><td>8</td><td>1140.3335</td><td>35.346584</td><td>17.458427</td><td>2.082356</td><td>0.006624071</td><td>0.00012574233</td><td>7.120322e-06</td><td>0.006005552</td><td>0.001574009</td><td>1.4136962e-05</td><td>0</td><td>special</td><td>dark</td><td>0.006624071</td></tr>\n",
@@ -935,7 +875,7 @@
        "39628295930644833 0.8380685984186204 ...    dark   0.0010364082"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -946,73 +886,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "2bc43807-3837-4a1b-aa63-1af7f37bd377",
+   "execution_count": 22,
+   "id": "aeb2d37e-fd69-403e-818b-6c7ff2acbc4a",
    "metadata": {},
    "outputs": [],
    "source": [
     "# QSO-maker redshift (Redrock or QN but not always same as FSF)\n",
     "T_qsom.rename_column('Z','Z_QSOM')\n",
-    "T_qsom.rename_column('SPECTYPE','SPECTYPE_QSOM')"
+    "T_qsom.rename_column('ZERR','ZERR_QSOM')\n",
+    "T_qsom.rename_column('SPECTYPE','SPECTYPE_QSOM')\n",
+    "T_qsom.rename_column('MORPHTYPE','MORPHTYPE_QSOM')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "id": "5f160b56-9362-4d21-aae7-8d1904436762",
+   "execution_count": 23,
+   "id": "6463e594-9a2c-4d6f-9064-887055beb253",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.95 s, sys: 668 ms, total: 9.62 s\n",
-      "Wall time: 9.6 s\n"
+      "CPU times: user 709 ms, sys: 434 ms, total: 1.14 s\n",
+      "Wall time: 1.15 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "## This is slow! Would it be faster to work with Pandas DataFrames?\n",
-    "## Takes >2min for Iron/DR1 without indexing tables\n",
-    "T_fsf_zpix_qsom = join(T_fsf_zpixsum, T_qsom, keys=keys_for_join, join_type='left')"
+    "# takes 11 sec for just qso-maker (56 sec for 3 tables)\n",
+    "# Convert to Pandas DataFrames for faster joining\n",
+    "df_qsom = T_qsom.to_pandas()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "120ceb54-851a-4dc1-b419-be95eda361ad",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2847435\n",
-      "1397603\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(len(T_qsom))\n",
-    "print(len(T_fsf_zpix_qsom))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "id": "1222c149d9f73a7c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "N_exptime0 = len(T_fsf_zpix_qsom[T_fsf_zpix_qsom['COADD_EXPTIME']==0.])\n",
-    "assert N_exptime0==0, print(f\"Found {N_exptime0} rows with COADD_EXPTIME=0; expected none.\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "0a36e106-7ad7-47e0-9497-80aa414bd314",
+   "execution_count": 24,
+   "id": "ae2f1909-4124-4dc3-8864-07c361a3dd18",
    "metadata": {},
    "outputs": [
     {
@@ -1021,16 +932,542 @@
        "0"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Clean up tables before doing the join\n",
+    "del T_qsom\n",
+    "gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "d4f9352f-7617-4817-ab7c-fb04740f9179",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 452 ms, sys: 229 ms, total: 682 ms\n",
+      "Wall time: 679 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "df_fsf = T_fsf.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "b73b712f-2d30-4bbb-9520-3b0728f07a7a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.43 s, sys: 0 ns, total: 1.43 s\n",
+      "Wall time: 1.43 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "df_fsf_qsom = pd.merge(df_fsf, df_qsom, on=keys_for_join, how='left')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "631b81a1-1967-41c3-8bef-d67937807c5b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.61 s, sys: 0 ns, total: 2.61 s\n",
+      "Wall time: 2.61 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "654"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Convert the final, joined DataFrame back to an Astropy Table for the rest of the pipeline\n",
+    "T_fsf_qsom = Table.from_pandas(df_fsf_qsom)\n",
+    "\n",
+    "# Clean up the joined DataFrame\n",
+    "del df_fsf_qsom\n",
+    "gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "004cf543-9393-4ccd-b147-b63084c5f434",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_exptime0 = len(T_fsf_qsom[T_fsf_qsom['COADD_EXPTIME']==0.])\n",
+    "assert N_exptime0==0, print(f\"Found {N_exptime0} rows with COADD_EXPTIME=0; expected none.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "f0aa938b-971d-4bc1-b9ec-fc96892e1062",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2 µs, sys: 0 ns, total: 2 µs\n",
+      "Wall time: 4.29 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "## This is slow! Would it be faster to work with Pandas DataFrames?\n",
+    "## Takes >2min for Iron/DR1 without indexing tables\n",
+    "#T_fsf_zpix_qsom = join(T_fsf_zpixsum, T_qsom, keys=keys_for_join, join_type='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "7820a5df-4f9d-4f3d-b208-99c06786e630",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# free memory\n",
+    "#del T_qsom\n",
+    "#del T_fsf\n",
+    "#gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "4807006b-1e4d-4fd9-b466-0d4bbabfde05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Inspect\n",
+    "#T_fsf_qsom.colnames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "8c5aacc9-a8bc-495b-a0c6-92b2ba907681",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=4</i>\n",
+       "<table id=\"table139851483325312\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>TARGETID</th><th>SURVEY</th><th>PROGRAM</th><th>LOGMSTAR</th><th>CIV_1549_FLUX</th><th>CIV_1549_FLUX_IVAR</th><th>CIV_1549_SIGMA</th><th>MGII_2796_FLUX</th><th>MGII_2796_FLUX_IVAR</th><th>MGII_2796_SIGMA</th><th>MGII_2803_FLUX</th><th>MGII_2803_FLUX_IVAR</th><th>MGII_2803_SIGMA</th><th>NEV_3426_FLUX</th><th>NEV_3426_FLUX_IVAR</th><th>OII_3726_FLUX</th><th>OII_3726_FLUX_IVAR</th><th>OII_3726_EW</th><th>OII_3726_EW_IVAR</th><th>OII_3729_FLUX</th><th>OII_3729_FLUX_IVAR</th><th>OII_3729_EW</th><th>OII_3729_EW_IVAR</th><th>HEII_4686_FLUX</th><th>HEII_4686_FLUX_IVAR</th><th>HBETA_FLUX</th><th>HBETA_FLUX_IVAR</th><th>HBETA_EW</th><th>HBETA_EW_IVAR</th><th>HBETA_BROAD_FLUX</th><th>HBETA_BROAD_FLUX_IVAR</th><th>HBETA_BROAD_SIGMA</th><th>HBETA_BROAD_CHI2</th><th>OIII_5007_FLUX</th><th>OIII_5007_FLUX_IVAR</th><th>OIII_5007_SIGMA</th><th>OI_6300_FLUX</th><th>OI_6300_FLUX_IVAR</th><th>HALPHA_FLUX</th><th>HALPHA_FLUX_IVAR</th><th>HALPHA_EW</th><th>HALPHA_EW_IVAR</th><th>HALPHA_BROAD_FLUX</th><th>HALPHA_BROAD_FLUX_IVAR</th><th>HALPHA_BROAD_VSHIFT</th><th>HALPHA_BROAD_SIGMA</th><th>NII_6584_FLUX</th><th>NII_6584_FLUX_IVAR</th><th>SII_6716_FLUX</th><th>SII_6716_FLUX_IVAR</th><th>SII_6731_FLUX</th><th>SII_6731_FLUX_IVAR</th><th>Z</th><th>ZWARN</th><th>DELTACHI2</th><th>SPECTYPE</th><th>Z_RR</th><th>PHOTSYS</th><th>LS_ID</th><th>FLUX_W1</th><th>FLUX_W2</th><th>FLUX_W3</th><th>FLUX_IVAR_W1</th><th>FLUX_IVAR_W2</th><th>FLUX_IVAR_W3</th><th>EBV</th><th>MW_TRANSMISSION_W1</th><th>MW_TRANSMISSION_W2</th><th>MW_TRANSMISSION_W3</th><th>Z_QSOM</th><th>ZERR_QSOM</th><th>SPECTYPE_QSOM</th><th>COADD_FIBERSTATUS</th><th>TARGET_RA</th><th>TARGET_DEC</th><th>MORPHTYPE_QSOM</th><th>MASKBITS</th><th>COADD_NUMEXP</th><th>COADD_EXPTIME</th><th>TSNR2_LYA</th><th>TSNR2_QSO</th><th>Z_QN</th><th>C_LYA</th><th>C_CIV</th><th>C_CIII</th><th>C_MgII</th><th>C_Hbeta</th><th>C_Halpha</th><th>QSO_MASKBITS</th><th>QN_C_LINE_BEST</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>str7</th><th>str6</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th><th>int64</th><th>float64</th><th>str6</th><th>float64</th><th>str1</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th><th>float64</th><th>str6</th><th>int32</th><th>float64</th><th>float64</th><th>str4</th><th>int16</th><th>int16</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int32</th><th>float32</th></tr></thead>\n",
+       "<tr><td>6448025174016</td><td>sv1</td><td>dark</td><td>5.599689</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.207667</td><td>0.7715051</td><td>12.637119</td><td>0.012325867</td><td>1.7035086</td><td>0.81847095</td><td>6.7112455</td><td>0.032602355</td><td>0.23363951</td><td>7.12369</td><td>1.4626874</td><td>9.650367</td><td>5.250497</td><td>0.5623618</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.0653974</td><td>9.83778</td><td>26.742447</td><td>0.2108098</td><td>24.551807</td><td>4.619172</td><td>27.473299</td><td>25.507624</td><td>0.076153</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.17415522</td><td>27.895308</td><td>0.7295528</td><td>20.016008</td><td>0.44656986</td><td>22.050251</td><td>0.022190569941649994</td><td>0</td><td>159.24895933177322</td><td>GALAXY</td><td>0.022190569941649994</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.02702388</td><td>0.9954307</td><td>0.99719137</td><td>0.9994003</td><td>0.022190569941649994</td><td>9.44955374671872e-06</td><td>GALAXY</td><td>0</td><td>179.15657</td><td>28.4234799</td><td></td><td>0</td><td>7</td><td>5531.698</td><td>463.37448</td><td>167.9584</td><td>1.0028983</td><td>0.00012917924</td><td>7.5691055e-06</td><td>9.611977e-05</td><td>0.0003871992</td><td>0.00021930125</td><td>8.6628625e-06</td><td>0</td><td>0.0003871992</td></tr>\n",
+       "<tr><td>6515536691200</td><td>sv1</td><td>dark</td><td>7.515767</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.24348228</td><td>0.041136403</td><td>1861.559</td><td>5.301754</td><td>0.04064875</td><td>1861.559</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.6408178</td><td>1.2575179</td><td>3.337212</td><td>0.04604701</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>100.13853</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.5364068034833155</td><td>4</td><td>2.663280975073576</td><td>GALAXY</td><td>0.5364068034833155</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.01879585</td><td>0.99681973</td><td>0.9980457</td><td>0.9995829</td><td>0.5364068034833155</td><td>9.685293065437282e-05</td><td>GALAXY</td><td>0</td><td>142.94811</td><td>31.82478</td><td></td><td>0</td><td>5</td><td>6000.266</td><td>177.85266</td><td>50.94038</td><td>3.4775233</td><td>9.8010096e-05</td><td>0.00055734697</td><td>0.00037833297</td><td>3.500392e-05</td><td>1.8670296e-05</td><td>3.1434952e-06</td><td>0</td><td>0.00055734697</td></tr>\n",
+       "<tr><td>6521555517440</td><td>sv1</td><td>dark</td><td>5.3910193</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.2341658</td><td>0.46782103</td><td>-5.48502</td><td>0.01780844</td><td>1.3066664</td><td>0.4660244</td><td>4.685097</td><td>0.02832791</td><td>0.9040468</td><td>4.4270067</td><td>0.6213819</td><td>6.4305325</td><td>6.4234667</td><td>0.03545121</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.20053317</td><td>4.606641</td><td>54.45429</td><td>0.7624382</td><td>5.852557</td><td>1.8667113</td><td>25.558912</td><td>13.227326</td><td>0.10789884</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.627051</td><td>16.401588</td><td>0.21906249</td><td>18.370296</td><td>0.010017642879535897</td><td>0</td><td>35.273709540546406</td><td>GALAXY</td><td>0.010017642879535897</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.010616658</td><td>0.9982024</td><td>0.99889565</td><td>0.9997644</td><td>0.010017642879535897</td><td>1.9457380880189815e-05</td><td>GALAXY</td><td>0</td><td>204.22749</td><td>32.09493</td><td></td><td>0</td><td>5</td><td>2588.5745</td><td>318.76593</td><td>127.40872</td><td>2.5613382</td><td>5.8894206e-05</td><td>0.0003162548</td><td>5.576252e-06</td><td>2.7044249e-05</td><td>3.31632e-06</td><td>2.4369754e-07</td><td>0</td><td>0.0003162548</td></tr>\n",
+       "<tr><td>6536638234624</td><td>sv1</td><td>dark</td><td>7.805484</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.5881265</td><td>0.504739</td><td>122.5513</td><td>9.485201e-07</td><td>6.0486813</td><td>0.500317</td><td>57.179882</td><td>0.00019526201</td><td>0.0</td><td>0.0</td><td>2.0062768</td><td>4.179936</td><td>7.5063195</td><td>0.12218019</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>3.685861</td><td>1.8641906</td><td>90.60073</td><td>0.36639658</td><td>6.5702343</td><td>5.9210873</td><td>12.381063</td><td>16.246782</td><td>0.5891032</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1.5307378</td><td>5.912066</td><td>3.4641097</td><td>6.3909593</td><td>0.52440584</td><td>1.9754051</td><td>0.07641158065394126</td><td>0</td><td>241.65000140666962</td><td>GALAXY</td><td>0.07641158065394126</td><td>S</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.019745098</td><td>0.9966594</td><td>0.9979471</td><td>0.9995618</td><td>0.07641158065394126</td><td>9.202724940035421e-06</td><td>GALAXY</td><td>0</td><td>186.274119</td><td>32.84503</td><td></td><td>0</td><td>3</td><td>1680.139</td><td>207.53513</td><td>72.701965</td><td>3.5479715</td><td>6.3469815e-05</td><td>1.5665793e-05</td><td>4.952881e-05</td><td>1.4830483e-05</td><td>1.4153613e-05</td><td>7.824195e-06</td><td>0</td><td>6.3469815e-05</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=4>\n",
+       "   TARGETID   SURVEY PROGRAM ...    C_Halpha   QSO_MASKBITS QN_C_LINE_BEST\n",
+       "    int64      str7    str6  ...    float32       int32        float32    \n",
+       "------------- ------ ------- ... ------------- ------------ --------------\n",
+       "6448025174016    sv1    dark ... 8.6628625e-06            0   0.0003871992\n",
+       "6515536691200    sv1    dark ... 3.1434952e-06            0  0.00055734697\n",
+       "6521555517440    sv1    dark ... 2.4369754e-07            0   0.0003162548\n",
+       "6536638234624    sv1    dark ...  7.824195e-06            0  6.3469815e-05"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "T_fsf_qsom[:4]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8726ce9f-35e5-4dfe-8b7d-4781b872049c",
+   "metadata": {},
+   "source": [
+    "## 3. Use the Redshift catalog (zall-pix or zcat VAC for Fuji)\n",
+    "\n",
+    "For Fuji (EDR), the Redshift Summary Catalog VAC supersedes the original redshift catalogs as described [here](https://data.desi.lbl.gov/doc/releases/edr/vac/zcat/). For Iron, we use directly the zall-pix. For Loa, we use the split version into survey-program combinations and with NSIDE1 healpixels for main-bright and main-dark."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "80ea6a3c-ed56-47ef-82c9-ab0a440abee8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if specprod == 'fuji':\n",
+    "    need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','ZERR','MORPHTYPE','TSNR2_LRG','SV_NSPEC','SV_PRIMARY',\n",
+    "                 'ZCAT_NSPEC','ZCAT_PRIMARY','MIN_MJD','MEAN_MJD','MAX_MJD', 'OBJTYPE'] # fuji\n",
+    "if specprod == 'guadalupe':\n",
+    "    need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','ZERR','MORPHTYPE','TSNR2_LRG','ZCAT_NSPEC','ZCAT_PRIMARY',\n",
+    "                 'MIN_MJD','MEAN_MJD','MAX_MJD','OBJTYPE'] # guadalupe\n",
+    "    # for guadalupe, iron, etc.: also add MAIN_PRIMARY and MAIN_NSPEC\n",
+    "if specprod == 'iron':\n",
+    "    need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','ZERR','MORPHTYPE','TSNR2_LRG','ZCAT_NSPEC','ZCAT_PRIMARY',\n",
+    "                 'SV_NSPEC','SV_PRIMARY','MAIN_PRIMARY','MAIN_NSPEC','MIN_MJD','MEAN_MJD','MAX_MJD','OBJTYPE']    \n",
+    "\n",
+    "if specprod == 'loa':\n",
+    "    need_cols = ['TARGETID','SURVEY','PROGRAM','HEALPIX','ZERR','MORPHTYPE','TSNR2_LRG','ZCAT_NSPEC','ZCAT_PRIMARY',\n",
+    "                 'SV_NSPEC','SV_PRIMARY','MAIN_PRIMARY','MAIN_NSPEC','MIN_MJD','MEAN_MJD','MAX_MJD','OBJTYPE']    \n",
+    "\n",
+    "# Replace targeting columns with updated version from zcat VAC (for Fuji), keeping BGS to find BGS_WISE targets\n",
+    "target_cols = ['DESI_TARGET','BGS_TARGET','SCND_TARGET','CMX_TARGET','SV1_DESI_TARGET','SV1_BGS_TARGET','SV1_SCND_TARGET',\n",
+    "               'SV2_DESI_TARGET','SV2_BGS_TARGET','SV2_SCND_TARGET','SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_SCND_TARGET']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "d3fec863-1132-4b92-bce8-9a33b657aa1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## For printing all columns in ext1 of zpix\n",
+    "#t1 = Table(fitsio.read(file_zpix_sum_cat, rows=[1,2], ext=1))\n",
+    "#t1.colnames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "21f1fcab-996e-4ea0-8e06-72a4b64eb4e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3.03 s, sys: 4.45 s, total: 7.48 s\n",
+      "Wall time: 46.2 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "## SJ: for faster performance, only read the desired columns with fitsio() from the zpix_sum file\n",
+    "T_zpixsum = Table(fitsio.read(file_zpix_sum_cat, columns=need_cols+target_cols, ext=1))\n",
+    "\n",
+    "# New: read as pandas dataframe instead of table\n",
+    "#df_zpixsum = fits_to_df(file_zpix_sum_cat, columns=need_cols+target_cols, ext=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "b113ebd9-c07c-4f39-8fcd-e1db8325ee57",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<TableColumns names=('TARGETID','SURVEY','PROGRAM','HEALPIX','ZERR','OBJTYPE','MORPHTYPE','CMX_TARGET','DESI_TARGET','BGS_TARGET','SCND_TARGET','SV1_DESI_TARGET','SV1_BGS_TARGET','SV1_SCND_TARGET','SV2_DESI_TARGET','SV2_BGS_TARGET','SV2_SCND_TARGET','SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_SCND_TARGET','TSNR2_LRG','SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY','MIN_MJD','MEAN_MJD','MAX_MJD')>"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "T_zpixsum.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "7d60859f-84bb-4687-a151-84d06d4a413a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2 µs, sys: 0 ns, total: 2 µs\n",
+      "Wall time: 5.25 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "## For testing only\n",
+    "#extra_cols = ['PHOTSYS','REF_CAT']\n",
+    "#T_zpixsum = Table(fitsio.read(file_zpix_sum_cat, columns=need_cols+target_cols+extra_cols, ext=1))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "10c8304c-2429-4f43-aa7d-3273492c86f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File = /global/cfs/cdirs/desi/spectro/redux/iron/zcatalog/v1/zall-pix-iron.fits\n",
+      "Morphtype = ; N = 6081275; Photsys = ['']; Ref_cat = ['' 'F1']\n",
+      "Morphtype = DEV; N = 2482746; Photsys = ['N' 'S']; Ref_cat = ['' 'G2' 'L3']\n",
+      "Morphtype = DUP; N = 11; Photsys = ['N' 'S']; Ref_cat = ['G2']\n",
+      "Morphtype = EXP; N = 1661446; Photsys = ['N' 'S']; Ref_cat = ['' 'G2' 'L3']\n",
+      "Morphtype = GGAL; N = 21938; Photsys = ['' 'G']; Ref_cat = ['G2']\n",
+      "Morphtype = GPSF; N = 1344882; Photsys = ['' 'G']; Ref_cat = ['G2']\n",
+      "Morphtype = PSF; N = 7311235; Photsys = ['N' 'S']; Ref_cat = ['' 'G2']\n",
+      "Morphtype = REX; N = 5313664; Photsys = ['N' 'S']; Ref_cat = ['' 'G2' 'L3']\n",
+      "Morphtype = SER; N = 4208766; Photsys = ['N' 'S']; Ref_cat = ['' 'G2' 'L3']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"File = {file_zpix_sum_cat}\")\n",
+    "morphtypes = np.unique(T_zpixsum['MORPHTYPE'])\n",
+    "for morphtyp in morphtypes:\n",
+    "    is_typ = T_zpixsum['MORPHTYPE']==morphtyp\n",
+    "    photsys = np.unique(T_zpixsum['PHOTSYS'][is_typ].data)\n",
+    "    ref_cat = np.unique(T_zpixsum['REF_CAT'][is_typ].data)\n",
+    "\n",
+    "    Nmorph = len(T_zpixsum[is_typ])\n",
+    "    print(f\"Morphtype = {morphtyp}; N = {Nmorph}; Photsys = {photsys}; Ref_cat = {ref_cat}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "deaa0ea8-cb86-44a6-949b-ac3eeaa33b51",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8.07 s, sys: 0 ns, total: 8.07 s\n",
+      "Wall time: 8.04 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "## This is slow! Would it be faster to work with Pandas DataFrames?\n",
+    "## Takes >2min for Iron/DR1 without indexing tables\n",
+    "T_fsf_zpix_qsom = join(T_fsf_qsom, T_zpixsum, keys=keys_for_join, join_type='left')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "9db33910-9006-414d-ac02-80bb4f47ea54",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2 µs, sys: 0 ns, total: 2 µs\n",
+      "Wall time: 4.05 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "## Convert to Pandas DataFrames for faster joining\n",
+    "#df_fsf = T_fsf.to_pandas()\n",
+    "#del T_fsf\n",
+    "#gc.collect()\n",
+    "#df_zpixsum = T_zpixsum.to_pandas()\n",
+    "#del T_zpixsum\n",
+    "#gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "44c88907-ae8d-4a39-b611-4cef6a27bff9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3 µs, sys: 0 ns, total: 3 µs\n",
+      "Wall time: 4.29 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Convert strings to categories to prevent memory crashes during the merge\n",
+    "#df_fsf['SURVEY'] = df_fsf['SURVEY'].astype('category')\n",
+    "#df_fsf['PROGRAM'] = df_fsf['PROGRAM'].astype('category')\n",
+    "#df_zpixsum['SURVEY'] = df_zpixsum['SURVEY'].astype('category')\n",
+    "#df_zpixsum['PROGRAM'] = df_zpixsum['PROGRAM'].astype('category')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "0a3331ae-4622-46f1-b322-574332be23b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2 µs, sys: 0 ns, total: 2 µs\n",
+      "Wall time: 4.29 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Takes 35 sec for DR1 with strings; sec with categories\n",
+    "## Join fsf and zpix dataframes\n",
+    "#df_joined = pd.merge(df_fsf, df_zpixsum, on=keys_for_join, how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "0693a11b-37d2-4bff-82a8-3210cebfa4c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "479"
+      ]
+     },
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# free memory\n",
-    "del T_qsom\n",
-    "del T_fsf_zpixsum\n",
+    "#del df_fsf\n",
+    "#del df_zpixsum\n",
     "gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82ce2e20-85a9-4e17-a06c-04da02a70e73",
+   "metadata": {},
+   "source": [
+    "### test: will join 3 tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "74aee87a-a052-4beb-ab26-bf65b6c47472",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# making sure this is the same size as before\n",
+    "#print(len(T_fsf_zpixsum))\n",
+    "#if len(T_fsf) == len(T_fsf_zpixsum):\n",
+    "#    print('Same length - all good')\n",
+    "#else:\n",
+    "#    print('The joined FastSpecFit and zpix catalog df is not the same size as the FastSpecFit catalog')\n",
+    "#    print('Something went wrong!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "fcb3ab7d-679f-4360-bb32-44a36557a7f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# free memory\n",
+    "#del T_fsf\n",
+    "#del T_zpixsum\n",
+    "#gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "d4aee53d-f9e7-4870-abc5-aba4039e8b0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check that cut on OBJTYPE was already made (shouldn't see an error message)\n",
+    "#assert len(T_fsf_zpixsum[T_fsf_zpixsum['OBJTYPE']!='TGT'])==0, print(\"Some rows have OBJTYPE != 'TGT'; expected zero.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "cd8ed949-1976-4a92-bd6d-dc9d88456d79",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Morphtype = ; N = 58145\n",
+      "Morphtype = DEV; N = 169389\n",
+      "Morphtype = EXP; N = 130007\n",
+      "Morphtype = GGAL; N = 1014\n",
+      "Morphtype = GPSF; N = 900\n",
+      "Morphtype = PSF; N = 338928\n",
+      "Morphtype = REX; N = 469269\n",
+      "Morphtype = SER; N = 229951\n"
+     ]
+    }
+   ],
+   "source": [
+    "morphtypes = np.unique(T_fsf_zpix_qsom['MORPHTYPE'])\n",
+    "for morphtyp in morphtypes:\n",
+    "    Nmorph = len(T_fsf_qsom[T_fsf_zpix_qsom['MORPHTYPE']==morphtyp])\n",
+    "    print(f\"Morphtype = {morphtyp}; N = {Nmorph}\")"
    ]
   },
   {
@@ -1038,7 +1475,7 @@
    "id": "fb6e478a",
    "metadata": {},
    "source": [
-    "## 4. Join FastPhot (not yet implemented)"
+    "## 4. Join FastPhot & CIGALE (not yet implemented)"
    ]
   },
   {
@@ -1093,7 +1530,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 51,
    "id": "9c44094d-9dec-4681-9649-3fefbe5effd9",
    "metadata": {},
    "outputs": [],
@@ -1104,7 +1541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 52,
    "id": "6fc3b3ac-56e5-4287-85ee-f95da620794f",
    "metadata": {},
    "outputs": [
@@ -1114,7 +1551,7 @@
        "0"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1135,7 +1572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 53,
    "id": "7ad0d94a6f1482d7",
    "metadata": {},
    "outputs": [],
@@ -1154,7 +1591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 54,
    "id": "ae316f6bbf612833",
    "metadata": {},
    "outputs": [
@@ -1180,7 +1617,7 @@
        "  - [RADIO,           17, \"Radio indicates AGN (not yet implemented)\"]"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1191,7 +1628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 55,
    "id": "a9dc464b8328fbd6",
    "metadata": {},
    "outputs": [
@@ -1244,7 +1681,7 @@
        "  - [BROAD_CIV,       42, \"CIV line with FWHM >=1200 km/s\"]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1255,7 +1692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 56,
    "id": "266f5ca2b9259883",
    "metadata": {},
    "outputs": [
@@ -1279,7 +1716,7 @@
        "  - [WISE_SF_H22,     13, \"WISE diagnostic Hviding et al. 2022 is not an AGN (based on W1,W2,W3)\"]"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1298,22 +1735,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 57,
    "id": "a264db45-ff5b-47d8-b166-ed6daa7767a2",
    "metadata": {},
    "outputs": [],
    "source": [
     "## Choose thresholds for S/N cuts on certain lines or quantities\n",
+    "\n",
+    "## TO DO: UPDATE THE DEFAULT VALUES TO 3 ALSO IN THE DIAGNOSTIC FUNCTIONS\n",
+    "\n",
     "snr_default = 3.0\n",
-    "snr_oi_default = 1.0\n",
+    "snr_oi_default = 3.0\n",
     "snr_oii_default = 3.0\n",
-    "snr_nev_default = 2.5\n",
+    "snr_nev_default = 3.0\n",
     "snr_wise_default = 3.0"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 58,
    "id": "d0fefb760c807339",
    "metadata": {},
    "outputs": [
@@ -1321,8 +1761,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 908 ms, sys: 0 ns, total: 908 ms\n",
-      "Wall time: 908 ms\n"
+      "CPU times: user 689 ms, sys: 0 ns, total: 689 ms\n",
+      "Wall time: 688 ms\n"
      ]
     }
    ],
@@ -1335,17 +1775,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 59,
    "id": "804ad00ef0f42f7c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<TableColumns names=('TARGETID','SURVEY','PROGRAM','LOGMSTAR','CIV_1549_FLUX','CIV_1549_FLUX_IVAR','CIV_1549_SIGMA','MGII_2796_FLUX','MGII_2796_FLUX_IVAR','MGII_2796_SIGMA','MGII_2803_FLUX','MGII_2803_FLUX_IVAR','MGII_2803_SIGMA','NEV_3426_FLUX','NEV_3426_FLUX_IVAR','OII_3726_FLUX','OII_3726_FLUX_IVAR','OII_3726_EW','OII_3726_EW_IVAR','OII_3729_FLUX','OII_3729_FLUX_IVAR','OII_3729_EW','OII_3729_EW_IVAR','HEII_4686_FLUX','HEII_4686_FLUX_IVAR','HBETA_FLUX','HBETA_FLUX_IVAR','HBETA_EW','HBETA_EW_IVAR','HBETA_BROAD_FLUX','HBETA_BROAD_FLUX_IVAR','HBETA_BROAD_SIGMA','HBETA_BROAD_CHI2','OIII_5007_FLUX','OIII_5007_FLUX_IVAR','OIII_5007_SIGMA','OI_6300_FLUX','OI_6300_FLUX_IVAR','HALPHA_FLUX','HALPHA_FLUX_IVAR','HALPHA_EW','HALPHA_EW_IVAR','HALPHA_BROAD_FLUX','HALPHA_BROAD_FLUX_IVAR','HALPHA_BROAD_VSHIFT','HALPHA_BROAD_SIGMA','NII_6584_FLUX','NII_6584_FLUX_IVAR','SII_6716_FLUX','SII_6716_FLUX_IVAR','SII_6731_FLUX','SII_6731_FLUX_IVAR','Z','ZWARN','DELTACHI2','SPECTYPE','Z_RR','PHOTSYS','LS_ID','FLUX_W1','FLUX_W2','FLUX_W3','FLUX_IVAR_W1','FLUX_IVAR_W2','FLUX_IVAR_W3','EBV','MW_TRANSMISSION_W1','MW_TRANSMISSION_W2','MW_TRANSMISSION_W3','HEALPIX','OBJTYPE','CMX_TARGET','DESI_TARGET','BGS_TARGET','SCND_TARGET','SV1_DESI_TARGET','SV1_BGS_TARGET','SV1_SCND_TARGET','SV2_DESI_TARGET','SV2_BGS_TARGET','SV2_SCND_TARGET','SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_SCND_TARGET','TSNR2_LRG','SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY','MIN_MJD','MEAN_MJD','MAX_MJD','Z_QSOM','ZERR','SPECTYPE_QSOM','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC','MORPHTYPE','MASKBITS','COADD_NUMEXP','COADD_EXPTIME','TSNR2_LYA','TSNR2_QSO','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','QSO_MASKBITS','QN_C_LINE_BEST','AGN_MASKBITS')>"
+       "<TableColumns names=('TARGETID','SURVEY','PROGRAM','LOGMSTAR','CIV_1549_FLUX','CIV_1549_FLUX_IVAR','CIV_1549_SIGMA','MGII_2796_FLUX','MGII_2796_FLUX_IVAR','MGII_2796_SIGMA','MGII_2803_FLUX','MGII_2803_FLUX_IVAR','MGII_2803_SIGMA','NEV_3426_FLUX','NEV_3426_FLUX_IVAR','OII_3726_FLUX','OII_3726_FLUX_IVAR','OII_3726_EW','OII_3726_EW_IVAR','OII_3729_FLUX','OII_3729_FLUX_IVAR','OII_3729_EW','OII_3729_EW_IVAR','HEII_4686_FLUX','HEII_4686_FLUX_IVAR','HBETA_FLUX','HBETA_FLUX_IVAR','HBETA_EW','HBETA_EW_IVAR','HBETA_BROAD_FLUX','HBETA_BROAD_FLUX_IVAR','HBETA_BROAD_SIGMA','HBETA_BROAD_CHI2','OIII_5007_FLUX','OIII_5007_FLUX_IVAR','OIII_5007_SIGMA','OI_6300_FLUX','OI_6300_FLUX_IVAR','HALPHA_FLUX','HALPHA_FLUX_IVAR','HALPHA_EW','HALPHA_EW_IVAR','HALPHA_BROAD_FLUX','HALPHA_BROAD_FLUX_IVAR','HALPHA_BROAD_VSHIFT','HALPHA_BROAD_SIGMA','NII_6584_FLUX','NII_6584_FLUX_IVAR','SII_6716_FLUX','SII_6716_FLUX_IVAR','SII_6731_FLUX','SII_6731_FLUX_IVAR','Z','ZWARN','DELTACHI2','SPECTYPE','Z_RR','PHOTSYS','LS_ID','FLUX_W1','FLUX_W2','FLUX_W3','FLUX_IVAR_W1','FLUX_IVAR_W2','FLUX_IVAR_W3','EBV','MW_TRANSMISSION_W1','MW_TRANSMISSION_W2','MW_TRANSMISSION_W3','Z_QSOM','ZERR_QSOM','SPECTYPE_QSOM','COADD_FIBERSTATUS','TARGET_RA','TARGET_DEC','MORPHTYPE_QSOM','MASKBITS','COADD_NUMEXP','COADD_EXPTIME','TSNR2_LYA','TSNR2_QSO','Z_QN','C_LYA','C_CIV','C_CIII','C_MgII','C_Hbeta','C_Halpha','QSO_MASKBITS','QN_C_LINE_BEST','HEALPIX','ZERR','OBJTYPE','MORPHTYPE','CMX_TARGET','DESI_TARGET','BGS_TARGET','SCND_TARGET','SV1_DESI_TARGET','SV1_BGS_TARGET','SV1_SCND_TARGET','SV2_DESI_TARGET','SV2_BGS_TARGET','SV2_SCND_TARGET','SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_SCND_TARGET','TSNR2_LRG','SV_NSPEC','SV_PRIMARY','ZCAT_NSPEC','ZCAT_PRIMARY','MIN_MJD','MEAN_MJD','MAX_MJD','AGN_MASKBITS')>"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1356,7 +1796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 60,
    "id": "6a109d54d0a6e67a",
    "metadata": {},
    "outputs": [
@@ -1383,7 +1823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 61,
    "id": "41ca947c29a861b8",
    "metadata": {},
    "outputs": [],
@@ -1395,7 +1835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 62,
    "id": "c4a60b34a5802149",
    "metadata": {},
    "outputs": [
@@ -1403,8 +1843,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 970 ms, sys: 0 ns, total: 970 ms\n",
-      "Wall time: 969 ms\n"
+      "CPU times: user 737 ms, sys: 0 ns, total: 737 ms\n",
+      "Wall time: 735 ms\n"
      ]
     }
    ],
@@ -1432,7 +1872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 63,
    "id": "98151ecd1c53e8b2",
    "metadata": {},
    "outputs": [
@@ -1442,7 +1882,7 @@
        "155350"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1455,7 +1895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 64,
    "id": "209c023b7566bd6d",
    "metadata": {},
    "outputs": [
@@ -1465,7 +1905,7 @@
        "46520"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1488,7 +1928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 65,
    "id": "c4adb51a9e06c7db",
    "metadata": {},
    "outputs": [],
@@ -1510,7 +1950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 66,
    "id": "de72a71797de7b50",
    "metadata": {},
    "outputs": [
@@ -1525,7 +1965,7 @@
        " 'COADD_EXPTIME': 's'}"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1541,7 +1981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 67,
    "id": "36c4c244b75957d5",
    "metadata": {},
    "outputs": [
@@ -1549,8 +1989,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 46.1 ms, sys: 687 µs, total: 46.8 ms\n",
-      "Wall time: 46.2 ms\n"
+      "CPU times: user 73 ms, sys: 0 ns, total: 73 ms\n",
+      "Wall time: 71.1 ms\n"
      ]
     }
    ],
@@ -1561,7 +2001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 68,
    "id": "b0fcb6586c73fdc7",
    "metadata": {},
    "outputs": [
@@ -1569,8 +2009,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 55 ms, sys: 31.7 ms, total: 86.7 ms\n",
-      "Wall time: 84.8 ms\n"
+      "CPU times: user 94.5 ms, sys: 0 ns, total: 94.5 ms\n",
+      "Wall time: 92.5 ms\n"
      ]
     }
    ],
@@ -1581,7 +2021,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 69,
    "id": "8da2a98fc097c75e",
    "metadata": {},
    "outputs": [],
@@ -1593,7 +2033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 70,
    "id": "4a8d92e3752b4ed8",
    "metadata": {},
    "outputs": [
@@ -1603,7 +2043,7 @@
        "6"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/AgnCats/py/uv_opt_agn_diagnostics.py
+++ b/AgnCats/py/uv_opt_agn_diagnostics.py
@@ -300,7 +300,7 @@ def sii_bpt(input_table: Table, snr: int | float = 3, kewley01: bool = False, ma
     return sii_bpt_avail, sf_sii, agn_sii, liner_sii
 
 
-def oi_bpt(input_table: Table, snr: int | float = 3, snr_oi: int | float = 1, kewley01: bool = False,
+def oi_bpt(input_table: Table, snr: int | float = 3, snr_oi: int | float = 3, kewley01: bool = False,
            mask: MaskedColumn = None) -> tuple[NDArray[bool], NDArray[bool], NDArray[bool], NDArray[bool]]:
     r"""[OI] diagnostic originally from [VO87]_.
 
@@ -336,7 +336,7 @@ def oi_bpt(input_table: Table, snr: int | float = 3, snr_oi: int | float = 1, ke
     Args:
         input_table: Table including [O I], H⍺, [OIII], Hβ fluxes and inverse variances.
         snr: SNR cut applied to H⍺, Hβ, and [OIII]. Default is ``3``.
-        snr_oi: SNR cut applied to the [OI]λ6300 emission line. Default is ``1``.
+        snr_oi: SNR cut applied to the [OI]λ6300 emission line. Default is ``3``.
         kewley01: Optional flag to use Kewley+01 lines for SF/AGN classification instead of Law+21 lines.
             Default is ``False``.
         mask: Optional mask (e.g., from masked column array). Default is ``None``.
@@ -797,7 +797,7 @@ def heii_bpt(input_table: Table, snr: int | float = 3, mask: MaskedColumn = None
     return heii_bpt_avail, agn_heii, sf_heii
 
 
-def nev(input_table: Table, snr: int | float = 2.5, mask: MaskedColumn = None) -> (
+def nev(input_table: Table, snr: int | float = 3, mask: MaskedColumn = None) -> (
         tuple[NDArray[bool], NDArray[bool], NDArray[bool]]):
     r"""[NeV] diagnostic based on high ionization potential.
 
@@ -813,7 +813,7 @@ def nev(input_table: Table, snr: int | float = 2.5, mask: MaskedColumn = None) -
 
     Args:
         input_table: Table including [NeV] flux and inverse variance.
-        snr: SNR cut applied to [NeV]. Default is ``2.5``.
+        snr: SNR cut applied to [NeV]. Default is ``3``.
         mask: Optional mask (e.g., from masked column array). Default is ``None``.
 
     Returns:


### PR DESCRIPTION
Updated the S/N threshold to 3 in all places except for the EW in WHAN for retired/passive galaxies. Swapped the order of the join in the notebook with (1) Fastspecfit; (2) QSO-maker; (3) Zpix redshift catalog. The notebooks is still messy with pandas dataframes vs. table join tests but the main new part to carry over is defining snr thresholds as variables.

Ran test catalog on EDR (still finding exclusive node was a bit slow)