### PR TITLE
update_pre-dr2_catalogs

### DIFF
--- a/AgnCats/py/build_desi_agngal_vac.py
+++ b/AgnCats/py/build_desi_agngal_vac.py
@@ -27,6 +27,7 @@ from desiutil.log import get_logger
 from AgnCats.py import set_agn_masksDESI as agn_masks
 
 logger = get_logger(level='INFO')
+
 import warnings
 warnings.filterwarnings('ignore')
 
@@ -34,6 +35,7 @@ warnings.filterwarnings('ignore')
 @dataclass(kw_only=True)
 class SpecProdInfo:
     """Data class for DESI specprod configuration information."""
+    name: str
     agn_bitmask_defs: str
     fast_spec: str
     fast_spec_data_cols: list[str]
@@ -65,7 +67,7 @@ def read_config(config_path: Path | str) -> dict[str, dict[str, SpecProdInfo]]:
 
     try:
         # Cast the nested dictionary in the configuration info as a SpecProdInfo data class to help with type checking.
-        config_info = {survey_name: {survey_program: SpecProdInfo(**config)
+        config_info = {survey_name: {survey_program: SpecProdInfo(name=f'{survey_name}_{survey_program}', **config)
                                      for survey_program, config in survey_config.items()}
                        for survey_name, survey_config in config_info.items()}
     except TypeError as e:
@@ -305,8 +307,8 @@ if __name__ == "__main__":
     # Provide CLI arguments for easy execution via SLURM scripts.
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', '--config', required=True, help='Path to configuration file.', type=Path)
-    parser.add_argument("-o", "--output", default="desi_agngal.fits", required=True,
-                        help="Path to output FITS file.", type=Path)
+    parser.add_argument('-o', '--output',  required=True, help='Path to output directory.', type=Path)
+    parser.add_argument('-v', '--version', required=True, help='Version number of catalog.', type=float)
     parser.add_argument('--testing', action='store_true', help=argparse.SUPPRESS)
     parser.add_argument('--testing-pp', action='store_true', help=argparse.SUPPRESS)
     args = parser.parse_args()
@@ -347,15 +349,10 @@ if __name__ == "__main__":
 
     else:
         # We need to assign unique output filenames for Loa catalogs based on the input catalog names.
-        output_filenames = [str(args.output / Path(f'desi_agngal_{spec_prod}_{survey_program}.fits'))
+        output_filenames = [str(args.output / Path(f'desi_agngal_{spec_prod}_{survey_program}_v{args.version}.fits'))
                             for survey_program in spec_prod_info[spec_prod].keys()]
 
         # Run all catalog operations in parallel simultaneously
         with mp.Pool() as pool:
             result = pool.starmap_async(build_agngal_catalog, zip(spec_prod_info[spec_prod].values(), output_filenames))
             result.get()
-    #
-    # else:
-    #     # For all previous data releases (EDR/Fuji, DR1/Iron) we will run the operations in serial.
-    #     spec_prod_info = spec_prod_info[spec_prod][f'{spec_prod}_all']
-    #     build_agngal_catalog(specprod_info=spec_prod_info, output_filename=str(args.output))

--- a/AgnCats/py/build_desi_agngal_vac.py
+++ b/AgnCats/py/build_desi_agngal_vac.py
@@ -345,17 +345,17 @@ if __name__ == "__main__":
             result = pool.starmap_async(build_agngal_catalog, zip(testing_info_set['loa'].values(), output_filenames))
             result.get()
 
-    elif spec_prod == 'loa':
+    else:
         # We need to assign unique output filenames for Loa catalogs based on the input catalog names.
-        output_filenames = [str(args.output / Path(f'desi_agngal_loa_{survey_program}.fits'))
-                            for survey_program in spec_prod_info['loa'].keys()]
+        output_filenames = [str(args.output / Path(f'desi_agngal_{spec_prod}_{survey_program}.fits'))
+                            for survey_program in spec_prod_info[spec_prod].keys()]
 
         # Run all catalog operations in parallel simultaneously
         with mp.Pool() as pool:
-            result = pool.starmap_async(build_agngal_catalog, zip(spec_prod_info['loa'].values(), output_filenames))
+            result = pool.starmap_async(build_agngal_catalog, zip(spec_prod_info[spec_prod].values(), output_filenames))
             result.get()
-
-    else:
-        # For all previous data releases (EDR/Fuji, DR1/Iron) we will run the operations in serial.
-        spec_prod_info = spec_prod_info[spec_prod][f'{spec_prod}_all']
-        build_agngal_catalog(specprod_info=spec_prod_info, output_filename=str(args.output))
+    #
+    # else:
+    #     # For all previous data releases (EDR/Fuji, DR1/Iron) we will run the operations in serial.
+    #     spec_prod_info = spec_prod_info[spec_prod][f'{spec_prod}_all']
+    #     build_agngal_catalog(specprod_info=spec_prod_info, output_filename=str(args.output))

--- a/AgnCats/py/generate_agngal_config.py
+++ b/AgnCats/py/generate_agngal_config.py
@@ -91,8 +91,9 @@ def generate_loa_config(specprod_info: dict[str, Path | list[str]], universal_in
 
     # Remove the full "main-bright" and "main-dark" entries in our grouped dictionary.
     # Due to extra files being present in QSO-Maker directory.
-    del all_catalogs_dict['main-bright']
-    del all_catalogs_dict['main-dark']
+    if specprod_name != 'fuji':
+        del all_catalogs_dict['main-bright']
+        del all_catalogs_dict['main-dark']
 
     # Convert the lists of file paths into dictionaries with the same structure as the dispatch patterns for previous
     # data releases
@@ -151,14 +152,18 @@ def loa_paths(file_paths: list[Path], specprod_info: dict[str, Path | list[str]]
 # EDR
 fuji_info = {
     # QSO-Maker catalog from Edmonds catalog keeping all columns
-    'qso_maker': f'{DESI_ROOT_RO}/users/edmondc/QSO_catalog/fuji/QSO_cat_fuji_healpix_all_targets_v2.fits',
+    # 'qso_maker': f'{DESI_ROOT_RO}/users/edmondc/QSO_catalog/fuji/QSO_cat_fuji_healpix_all_targets_v2.fits',
+    'qso_maker_dir': Path('/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/qsom'),
+    'qso_maker_cols': ['QN_C_LINE_BEST'],
 
     # FastSpecFit catalog
-    'fast_spec': f'{DESI_ROOT_RO}/spectro/fastspecfit/fuji/v3.2/catalogs/fastspec-fuji.fits',
+    # 'fast_spec': f'{DESI_ROOT_RO}/spectro/fastspecfit/fuji/v3.2/catalogs/fastspec-fuji.fits',
+    'fast_spec_dir': Path('/global/cfs/cdirs/desi/public/edr/vac/edr/fastspecfit/fuji/v3.2/catalogs/'),
     'fast_spec_data_cols': ['LOGMSTAR'],
 
     # Redshift catalog
-    'zcat': f'{DESI_ROOT_RO}/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits',
+    # 'zcat': f'{DESI_ROOT_RO}/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits',
+    'zcat_dir': Path('/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/zcat'),
     'zcat_cols': ['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'ZERR', 'TSNR2_LRG', 'SV_NSPEC', 'SV_PRIMARY',
                   'ZCAT_NSPEC', 'ZCAT_PRIMARY', 'MIN_MJD', 'MEAN_MJD', 'MAX_MJD', 'OBJTYPE'],
 
@@ -180,15 +185,19 @@ fuji_info = {
 # DR1
 iron_info = {
     # QSO-Maker catalog from `merge_QSOmaker.ipynb`. DR1 version from after Edmond ran on all targets/all surveys
-    'qso_maker': f'{DESI_ROOT_RO}/science/gqp/agncatalog/qsomaker/iron/QSO_cat_iron_healpix_all_targets_v1.fits',
+    # 'qso_maker': f'{DESI_ROOT_RO}/science/gqp/agncatalog/qsomaker/iron/QSO_cat_iron_healpix_all_targets_v1.fits',
+    'qso_maker_dir': Path('/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/qsom'),
     'qso_maker_cols': ['QN_C_LINE_BEST'],
 
     # FastSpecFit catalog
-    'fast_spec': f'{DESI_ROOT_RO}/spectro/fastspecfit/iron/v2.1/catalogs/fastspec-iron.fits',
-    'fast_spec_data_cols': ['LOGMSTAR'],
+    # 'fast_spec': f'{DESI_ROOT_RO}/spectro/fastspecfit/iron/v2.1/catalogs/fastspec-iron.fits',
+    'fast_spec_dir': Path('/global/cfs/cdirs/desi/public/dr1/vac/dr1/fastspecfit/iron/v3.0/catalogs'),
+    # 'fast_spec_data_cols': ['LOGMSTAR'],
+    'fast_spec_specphot_cols': ['TARGETID', 'PROGRAM', 'SURVEY', 'LOGMSTAR', 'LOGMSTAR_IVAR'],
 
     # Redshift catalog
-    'zcat': f'{DESI_ROOT_RO}/spectro/redux/iron/zcatalog/v1/zall-pix-iron.fits',
+    # 'zcat': f'{DESI_ROOT_RO}/spectro/redux/iron/zcatalog/v1/zall-pix-iron.fits',
+    'zcat_dir': Path('/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/zcat'),
     'zcat_cols': ['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'ZERR', 'TSNR2_LRG', 'ZCAT_NSPEC',
                   'ZCAT_PRIMARY', 'SV_NSPEC', 'SV_PRIMARY', 'MAIN_PRIMARY', 'MAIN_NSPEC', 'MIN_MJD', 'MEAN_MJD',
                   'MAX_MJD', 'OBJTYPE'],
@@ -310,12 +319,18 @@ all_data_release_info = {
 }
 
 if __name__ == '__main__':
-    generate_fuji_iron_config(specprod_info=fuji_info, universal_info=all_data_release_info,
-                              config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/fuji_config.yaml'),
-                              specprod_name='fuji')
-    generate_fuji_iron_config(specprod_info=iron_info, universal_info=all_data_release_info,
-                              config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/iron_config.yaml'),
-                              specprod_name='iron')
+    # generate_fuji_iron_config(specprod_info=fuji_info, universal_info=all_data_release_info,
+    #                           config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/fuji_config.yaml'),
+    #                           specprod_name='fuji')
+    # generate_fuji_iron_config(specprod_info=iron_info, universal_info=all_data_release_info,
+    #                           config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/iron_config.yaml'),
+    #                           specprod_name='iron')
+    generate_loa_config(specprod_info=fuji_info, universal_info=all_data_release_info,
+                        config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/fuji_split_config.yaml'),
+                        specprod_name='fuji')
+    generate_loa_config(specprod_info=iron_info, universal_info=all_data_release_info,
+                        config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/iron_split_config.yaml'),
+                        specprod_name='iron')
     generate_loa_config(specprod_info=loa_base_info, universal_info=all_data_release_info,
                         config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/loa_config.yaml'),
                         specprod_name='loa')

--- a/AgnCats/py/generate_agngal_config.py
+++ b/AgnCats/py/generate_agngal_config.py
@@ -16,52 +16,14 @@ import yaml
 
 DESI_ROOT_RO = os.getenv('DESI_ROOT_READONLY', None)
 
-
-def generate_fuji_iron_config(specprod_info: dict[str, str | list[str]], universal_info: dict[str, str | list[str]],
-                              config_file_name: Path, specprod_name: str):
-    """Processes the EDR and DR1 configuration information into a YAML file.
-
-    As these data releases are simple, we only need to combine the data-release specific information with the universal
-    information and output the dictionary to the configuration file.
-
-    Args:
-        specprod_info:
-            Dictionary containing paths to find the relevant catalogs for EDR or DR1. Additionally, any
-            associated data-release specific column names that should be included in the final configuration file.
-        universal_info:
-            Dictionary containing paths to find the relevant files or input and output catalog column names that are
-            universal to all data releases.
-        config_file_name:
-            Path to output configuration file containing all relevant information to build the targeted data release
-            VAC.
-        specprod_name:
-            Name to assign the top-level label of the dictionary/yaml file. Should be ``'fuji'`` or ``'iron'``.
-    """
-
-    # Merge the column lists between the data release-specific and universal lists.
-    merged_column_lists = {list_name: [*specprod_info[list_name], *universal_info[list_name]]
-                           for list_name in set(specprod_info.keys()).intersection(universal_info.keys())}
-
-
-    # Simply union the two dictionaries together to create the complete data-release configuration.
-    data_release_info = specprod_info | universal_info | merged_column_lists
-
-    # In order to preserve consistency with the Loa data release configuration we need to nest our dictionary.
-    data_release_info = {f'{specprod_name}': {f'{specprod_name}_all': data_release_info}}
-
-    # Write the configuration to file
-    with open(config_file_name, 'w') as config_file:
-        yaml.safe_dump(data_release_info, config_file)
-
-
-def generate_loa_config(specprod_info: dict[str, Path | list[str]], universal_info: dict[str, str | list[str]],
+def generate_config(specprod_info: dict[str, Path | list[str]], universal_info: dict[str, str | list[str]],
                         config_file_name: Path, specprod_name: str):
-    """Processes the DR2 suite of catalogs into dispatchers matching the scheme for EDR and DR1.
+    """Processes the suite of catalogs into configuration structures.
 
     Args:
         specprod_info:
-            Dictionary containing paths to directories to find the relevant catalogs for DR2. Additionally, any
-            associated data-release specific column names that should be included in the final dispatcher.
+            Dictionary containing paths to directories to find the relevant catalogs for the data release. Additionally,
+            any associated data-release specific column names that should be included in the final configuration.
         universal_info:
             Dictionary containing paths to find the relevant files or input and output catalog column names that are
             universal to all data releases.
@@ -69,12 +31,12 @@ def generate_loa_config(specprod_info: dict[str, Path | list[str]], universal_in
             Path to output configuration file containing all relevant information to build the targeted data release
             VAC.
         specprod_name:
-            Name to assign the top-level label of the dictionary/yaml file. Should be ``'loa'``.
+            Name to assign the top-level label of the dictionary/yaml file.
 
     Returns:
-        Dispatch patterns matching required path names and column names for catalog input. Each dispatch pattern is
-        identified by the DESI ``<Survey>-<Program>[-nside1-hp<HEALPix>]`` naming scheme e.g.,
-        "main-dark-nside1-hp00" or "sv1-bright".
+        Configuration information matching required path names and column names for catalog input.
+        Each configuration structure is identified by the DESI ``<Survey>-<Program>[-nside1-hp<HEALPix>]`` naming scheme
+         e.g., "main-dark-nside1-hp00" or "sv1-bright".
     """
 
     # Define a RegEx pattern for the file grouping names
@@ -91,32 +53,32 @@ def generate_loa_config(specprod_info: dict[str, Path | list[str]], universal_in
 
     # Remove the full "main-bright" and "main-dark" entries in our grouped dictionary.
     # Due to extra files being present in QSO-Maker directory.
-    if specprod_name != 'fuji':
+    if ('main-bright' in all_catalogs_dict) or ('main-dark' in all_catalogs_dict):
         del all_catalogs_dict['main-bright']
         del all_catalogs_dict['main-dark']
 
-    # Convert the lists of file paths into dictionaries with the same structure as the dispatch patterns for previous
-    # data releases
-    loa_info = {survey_program: loa_paths(catalog_paths, specprod_info)
-                for survey_program, catalog_paths in all_catalogs_dict.items()}
+    # Convert the lists of file paths into dictionaries sorted by catalog type
+    data_release_info = {survey_program: catalog_paths(cat_paths, specprod_info)
+                         for survey_program, cat_paths in all_catalogs_dict.items()}
 
-    # Extract all data for all the column data common to all survey-program(-healpix) subcatalog of Loa
-    all_loa_info = {label: info for label, info in specprod_info.items() if 'cols' in label}
+    # Extract all data for all the column data common to all survey-program(-healpix) subcatalogs
+    all_survey_program_info = {label: info for label, info in specprod_info.items() if 'cols' in label}
 
     # Merge the column lists between the data release-specific and universal lists.
-    merged_column_lists = {list_name: [*all_loa_info[list_name], *universal_info[list_name]]
-                           for list_name in set(all_loa_info.keys()).intersection(universal_info.keys())}
+    merged_column_lists = {list_name: [*all_survey_program_info[list_name], *universal_info[list_name]]
+                           for list_name in set(all_survey_program_info.keys()).intersection(universal_info.keys())}
 
-    # To each survey-program(-healpix) subcatalog of Loa, union the universal info dictionary.
-    loa_info = {f'{specprod_name}': {survey_program: survey_program_info | all_loa_info | universal_info | merged_column_lists
-                 for survey_program, survey_program_info in loa_info.items()}}
+    # To each survey-program(-healpix) subcatalog, union the universal info dictionary.
+    data_release_info = {f'{specprod_name}': {survey_program: survey_program_info | all_survey_program_info
+                                                              | universal_info | merged_column_lists
+                                              for survey_program, survey_program_info in data_release_info.items()}}
 
     # Write the configuration to file
     with open(config_file_name, 'w') as config_file:
-        yaml.safe_dump(loa_info, config_file)
+        yaml.safe_dump(data_release_info, config_file)
 
 
-def loa_paths(file_paths: list[Path], specprod_info: dict[str, Path | list[str]]) -> dict[str, str]:
+def catalog_paths(file_paths: list[Path], specprod_info: dict[str, Path | list[str]]) -> dict[str, str]:
     """Parse a list of file paths into a dictionary with keys matching the expected dispatch pattern
 
     Args:
@@ -154,12 +116,11 @@ fuji_info = {
     # QSO-Maker catalog from Edmonds catalog keeping all columns
     # 'qso_maker': f'{DESI_ROOT_RO}/users/edmondc/QSO_catalog/fuji/QSO_cat_fuji_healpix_all_targets_v2.fits',
     'qso_maker_dir': Path('/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/qsom'),
-    'qso_maker_cols': ['QN_C_LINE_BEST'],
 
     # FastSpecFit catalog
     # 'fast_spec': f'{DESI_ROOT_RO}/spectro/fastspecfit/fuji/v3.2/catalogs/fastspec-fuji.fits',
     'fast_spec_dir': Path('/global/cfs/cdirs/desi/public/edr/vac/edr/fastspecfit/fuji/v3.2/catalogs/'),
-    'fast_spec_data_cols': ['LOGMSTAR'],
+    'fast_spec_data_cols': ['LOGMSTAR',  'RCHI2', 'RCHI2_LINE', 'RCHI2_CONT', 'RCHI2_PHOT'],
 
     # Redshift catalog
     # 'zcat': f'{DESI_ROOT_RO}/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits',
@@ -185,18 +146,14 @@ fuji_info = {
 # DR1
 iron_info = {
     # QSO-Maker catalog from `merge_QSOmaker.ipynb`. DR1 version from after Edmond ran on all targets/all surveys
-    # 'qso_maker': f'{DESI_ROOT_RO}/science/gqp/agncatalog/qsomaker/iron/QSO_cat_iron_healpix_all_targets_v1.fits',
     'qso_maker_dir': Path('/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/qsom'),
-    'qso_maker_cols': ['QN_C_LINE_BEST'],
 
     # FastSpecFit catalog
-    # 'fast_spec': f'{DESI_ROOT_RO}/spectro/fastspecfit/iron/v2.1/catalogs/fastspec-iron.fits',
-    'fast_spec_dir': Path('/global/cfs/cdirs/desi/public/dr1/vac/dr1/fastspecfit/iron/v3.0/catalogs'),
-    # 'fast_spec_data_cols': ['LOGMSTAR'],
-    'fast_spec_specphot_cols': ['TARGETID', 'PROGRAM', 'SURVEY', 'LOGMSTAR', 'LOGMSTAR_IVAR'],
+    'fast_spec_dir': Path(f'{DESI_ROOT_RO}/public/dr1/vac/dr1/fastspecfit/iron/v3.0/catalogs'),
+    'fast_spec_specphot_cols': ['TARGETID', 'PROGRAM', 'SURVEY', 'LOGMSTAR', 'LOGMSTAR_IVAR',
+                                'RCHI2', 'RCHI2_LINE', 'RCHI2_CONT', 'RCHI2_PHOT'],
 
     # Redshift catalog
-    # 'zcat': f'{DESI_ROOT_RO}/spectro/redux/iron/zcatalog/v1/zall-pix-iron.fits',
     'zcat_dir': Path('/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/zcat'),
     'zcat_cols': ['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'ZERR', 'TSNR2_LRG', 'ZCAT_NSPEC',
                   'ZCAT_PRIMARY', 'SV_NSPEC', 'SV_PRIMARY', 'MAIN_PRIMARY', 'MAIN_NSPEC', 'MIN_MJD', 'MEAN_MJD',
@@ -214,7 +171,10 @@ iron_info = {
                          'DESI_TARGET', 'SCND_TARGET', 'BGS_TARGET', 'CMX_TARGET',
                          'SV1_DESI_TARGET', 'SV2_DESI_TARGET', 'SV3_DESI_TARGET',
                          'SV1_BGS_TARGET', 'SV2_BGS_TARGET', 'SV3_BGS_TARGET',
-                         'SV1_SCND_TARGET', 'SV2_SCND_TARGET', 'SV3_SCND_TARGET']
+                         'SV1_SCND_TARGET', 'SV2_SCND_TARGET', 'SV3_SCND_TARGET'],
+
+    # Output catalog extension 2 column names
+    'output_cols_ext2': ['LOGMSTAR_IVAR']
 }
 
 # DR2
@@ -224,8 +184,8 @@ loa_base_info = {
 
     # FastSpecFit Catalog
     'fast_spec_dir': Path(f'{DESI_ROOT_RO}/vac/dr2/fastspecfit/loa/v1.0/catalogs'),
-
-    'fast_spec_specphot_cols': ['TARGETID', 'PROGRAM', 'SURVEY', 'LOGMSTAR'],
+    'fast_spec_specphot_cols': ['TARGETID', 'PROGRAM', 'SURVEY', 'LOGMSTAR', 'LOGMSTAR_IVAR',
+                                'RCHI2', 'RCHI2_LINE', 'RCHI2_CONT', 'RCHI2_PHOT'],
 
     # Redshift Catalog
     'zcat_dir': Path(f'{DESI_ROOT_RO}/science/gqp/agncatalog/zpix_nside1/loa/v1'),
@@ -245,7 +205,10 @@ loa_base_info = {
                          'DESI_TARGET', 'SCND_TARGET', 'BGS_TARGET', 'CMX_TARGET',
                          'SV1_DESI_TARGET', 'SV2_DESI_TARGET', 'SV3_DESI_TARGET',
                          'SV1_BGS_TARGET', 'SV2_BGS_TARGET', 'SV3_BGS_TARGET',
-                         'SV1_SCND_TARGET', 'SV2_SCND_TARGET', 'SV3_SCND_TARGET']
+                         'SV1_SCND_TARGET', 'SV2_SCND_TARGET', 'SV3_SCND_TARGET'],
+
+    # Output catalog extension 2 column names
+    'output_cols_ext2': ['LOGMSTAR_IVAR']
 }
 
 all_data_release_info = {
@@ -258,7 +221,6 @@ all_data_release_info = {
 
     # Universal input catalog column names
     'fast_spec_data_cols': ['TARGETID', 'PROGRAM', 'SURVEY',
-                            'RCHI2', 'RCHI2_LINE', 'RCHI2_CONT', 'RCHI2_PHOT',
                             'CIV_1549_FLUX', 'CIV_1549_FLUX_IVAR', 'CIV_1549_SIGMA',
                             'MGII_2796_FLUX', 'MGII_2796_FLUX_IVAR', 'MGII_2796_SIGMA',
                             'MGII_2803_FLUX', 'MGII_2803_FLUX_IVAR', 'MGII_2803_SIGMA',
@@ -296,8 +258,9 @@ all_data_release_info = {
                   'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_SCND_TARGET'],
 
     # Universal output catalog column names
-    'output_cols_ext2': ['TARGETID', 'SURVEY', 'PROGRAM', 'LOGMSTAR',
-                         'RCHI2', 'RCHI2_LINE', 'RCHI2_CONT', 'RCHI2_PHOT'
+    'output_cols_ext2': ['TARGETID', 'SURVEY', 'PROGRAM',
+                         'LOGMSTAR',
+                         'RCHI2', 'RCHI2_LINE', 'RCHI2_CONT', 'RCHI2_PHOT',
                          'FLUX_W1', 'FLUX_W2', 'FLUX_W3',
                          'FLUX_IVAR_W1', 'FLUX_IVAR_W2', 'FLUX_IVAR_W3',
                          'CIV_1549_FLUX', 'CIV_1549_FLUX_IVAR', 'CIV_1549_SIGMA',
@@ -319,18 +282,12 @@ all_data_release_info = {
 }
 
 if __name__ == '__main__':
-    # generate_fuji_iron_config(specprod_info=fuji_info, universal_info=all_data_release_info,
-    #                           config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/fuji_config.yaml'),
-    #                           specprod_name='fuji')
-    # generate_fuji_iron_config(specprod_info=iron_info, universal_info=all_data_release_info,
-    #                           config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/iron_config.yaml'),
-    #                           specprod_name='iron')
-    generate_loa_config(specprod_info=fuji_info, universal_info=all_data_release_info,
-                        config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/fuji_split_config.yaml'),
-                        specprod_name='fuji')
-    generate_loa_config(specprod_info=iron_info, universal_info=all_data_release_info,
-                        config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/iron_split_config.yaml'),
-                        specprod_name='iron')
-    generate_loa_config(specprod_info=loa_base_info, universal_info=all_data_release_info,
-                        config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/loa_config.yaml'),
-                        specprod_name='loa')
+    generate_config(specprod_info=fuji_info, universal_info=all_data_release_info,
+                    config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/fuji_split_config.yaml'),
+                    specprod_name='fuji')
+    generate_config(specprod_info=iron_info, universal_info=all_data_release_info,
+                    config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/iron_split_config.yaml'),
+                    specprod_name='iron')
+    generate_config(specprod_info=loa_base_info, universal_info=all_data_release_info,
+                    config_file_name=Path('/global/u2/b/bfloyd/agngal_dr2/AgnCats/py/configs/loa_config.yaml'),
+                    specprod_name='loa')

--- a/AgnCats/py/split_input_catalogs.py
+++ b/AgnCats/py/split_input_catalogs.py
@@ -13,6 +13,7 @@ from astropy.table import Table
 import fitsio
 from pathlib import Path
 from desiutil.healpix import radec2hpix
+from astropy.io import fits
 
 def split_by_healpix(catalog: Table, nside: int) -> Table:
     """Takes a catalog that is already grouped by Survey-Program and further groups by HEALPix of size ``nside``.
@@ -59,7 +60,7 @@ def split_qsomaker(catalog_file: str, out_dir: str, specprod: str, version: int 
     """
 
     # Read in the monolithic catalog
-    qsom = Table(fitsio.read(catalog_file, ext='QSO_CAT'))
+    qsom = Table(fitsio.read(catalog_file, ext=1))
 
     # Group the catalog by Survey-Program
     qsom = qsom.group_by(['SURVEY', 'PROGRAM'])
@@ -102,16 +103,20 @@ def split_qsomaker(catalog_file: str, out_dir: str, specprod: str, version: int 
         qn_high_conf_50 = subcat['QN_C_LINE_BEST'] > 0.5
         subcat = subcat[(~is_star) & qn_high_conf_50]
 
+        # Prepare the output file
+        primary_hdu = fits.PrimaryHDU()
+        subcat_hdu = fits.BinTableHDU(subcat, name='QSO_CAT')
+        hdu_list = fits.HDUList([primary_hdu, subcat_hdu])
+
         # Write the file out copying
         if len(subcat_key) == 3:
             survey, program, nside1_hp = subcat_key
-            subcat.write(f'{out_dir}/QSO_cat_{specprod}_{survey}_{program}_nside1_hp{nside1_hp:02d}'
-                         f'_healpix_all_targets_v{version}.fits',
-                         hdu='QSO_CAT', overwrite=True)
+            hdu_list.writeto(f'{out_dir}/QSO_cat_{specprod}_{survey}_{program}_nside1_hp{nside1_hp:02d}'
+                             f'_healpix_all_targets_v{version}.fits', overwrite=True, checksum=True)
         else:
             survey, program = subcat_key
-            subcat.write(f'{out_dir}/QSO_cat_{specprod}_{survey}_{program}_healpix_all_targets_v{version}.fits',
-                         hdu='QSO_CAT', overwrite=True)
+            hdu_list.writeto(f'{out_dir}/QSO_cat_{specprod}_{survey}_{program}_healpix_all_targets_v{version}.fits',
+                             overwrite=True, checksum=True)
 
 
 def split_zcat(catalog_file: str, out_dir: str, specprod: str, version: int|float) -> None:
@@ -158,14 +163,20 @@ def split_zcat(catalog_file: str, out_dir: str, specprod: str, version: int|floa
 
     # Write out all the catalogs
     for subcat_key, subcat in zcat_subcats.items():
+        # Prepare the output file
+        primary_hdu = fits.PrimaryHDU()
+        subcat_hdu = fits.BinTableHDU(subcat, name='ZCATALOG')
+        hdu_list = fits.HDUList([primary_hdu, subcat_hdu])
+
         if len(subcat_key) == 3:
             survey, program, nside1_hp = subcat_key
-            subcat.write(f'{out_dir}/zpix_cat_{specprod}_{survey}_{program}_nside1_hp{nside1_hp:02d}_v{version}.fits',
-                         hdu='ZCATALOG', overwrite=True)
+            hdu_list.writeto(f'{out_dir}/zpix_cat_{specprod}_{survey}_{program}'
+                             f'_nside1_hp{nside1_hp:02d}_v{version}.fits',
+                             overwrite=True, checksum=True)
         else:
             survey, program = subcat_key
-            subcat.write(f'{out_dir}/zpix_cat_{specprod}_{survey}_{program}_v{version}.fits',
-                         hdu='ZCATALOG', overwrite=True)
+            hdu_list.writeto(f'{out_dir}/zpix_cat_{specprod}_{survey}_{program}_v{version}.fits',
+                             overwrite=True, checksum=True)
 
 if __name__ == '__main__':
     # Split Fuji
@@ -175,8 +186,8 @@ if __name__ == '__main__':
     fuji_qso_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/qsom'
     fuji_zcat_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/zcat'
 
-    iron_qsom = '/dvs_ro/cfs/cdirs/desi/users/edmondc/QSO_catalog/fuji/QSO_cat_fuji_healpix_all_targets_v2.fits'
-    iron_zcat = '/dvs_ro/cfs/cdirs/desi/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits'
+    iron_qsom = '/dvs_ro/cfs/cdirs/desi/science/gqp/agncatalog/qsomaker/iron/QSO_cat_iron_healpix_all_targets_v1.fits'
+    iron_zcat = '/dvs_ro/cfs/cdirs/desi/spectro/redux/iron/zcatalog/v1/zall-pix-iron.fits'
 
     iron_qso_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/qsom'
     iron_zcat_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/zcat'

--- a/AgnCats/py/split_input_catalogs.py
+++ b/AgnCats/py/split_input_catalogs.py
@@ -37,20 +37,18 @@ def split_by_healpix(catalog: Table, nside: int) -> Table:
 
     return catalog_grp
 
-def split_qsomaker(catalog_file: str, out_dir: str, specprod: str, version: int | float) -> None:
-    """Splits an input monolithic QSO-Maker catalog into sub-catalogs split by Survey-Program(-nside1_hpXX).
+def split_catalogs(catalog_file: str, out_prefix: str, out_dir: str, specprod: str, version: int | float) -> None:
+    """Splits an input monolithic catalog into sub-catalogs split by Survey-Program(-nside1_hpXX).
 
     Most sub-catalogs will just be split by Survey-Program with the exception of ``Main-Bright`` and ``Main-Dark``.
     These sub-catalogs are often very large, and thus we further split by HEALPix of nside=1.
     This is largely to match the subdivision adopted by FastSpec and FastPhot catalogs.
 
-    We also perform some cuts on the output catalogs, removing stars and low-redshift objects while retaining
-    high-confidence QuasarNet cases.
-    We also compute the confidence values of the best and second-best emission lines as found by QuasarNet.
-
     Args:
         catalog_file:
             Path to monolithic QSO-Maker catalog to split.
+        out_prefix:
+            Prefix to place in output file name. E.g., "QSO" or "zpix" for QSO-Maker or Redshift catalogs respectively.
         out_dir:
             Path to directory to save split catalogs to.
         specprod:
@@ -60,141 +58,58 @@ def split_qsomaker(catalog_file: str, out_dir: str, specprod: str, version: int 
     """
 
     # Read in the monolithic catalog
-    qsom = Table(fitsio.read(catalog_file, ext=1))
+    catalog = Table(fitsio.read(catalog_file, ext=1))
 
     # Group the catalog by Survey-Program
-    qsom = qsom.group_by(['SURVEY', 'PROGRAM'])
+    catalog = catalog.group_by(['SURVEY', 'PROGRAM'])
 
     # First, we will split the catalog by survey-program-nside1-hpXX
-    qsom_subcats = {}
-    for sp_grp, sp_grp_key in zip(qsom.groups, qsom.groups.keys.iterrows()):
+    subcats = {}
+    for sp_grp, sp_grp_key in zip(catalog.groups, catalog.groups.keys.iterrows()):
         match sp_grp_key:
             # If catalog group is main-dark or main-bright, we need to further split by HEALPix (nside=1)
             case ('main', 'dark') | ('main', 'bright'):
                 sp_hp_cat = split_by_healpix(sp_grp, nside=1)
                 for sphp_grp, sphp_grp_key in zip(sp_hp_cat.groups, sp_hp_cat.groups.keys.iterrows()):
-                    qsom_subcats[sphp_grp_key] = sphp_grp
+                    subcats[sphp_grp_key] = sphp_grp
 
             # For all other cases, we just need the survey-program split
             case _:
-                qsom_subcats[sp_grp_key] = sp_grp
+                subcats[sp_grp_key] = sp_grp
 
     # Iterate over the sub-catalogs to process and write out
-    for subcat_key, subcat in qsom_subcats.items():
-        # Keep only Target Object types if ``OBJTYPE`` column exists
-        if 'OBJTYPE' in subcat.colnames:
-            subcat = subcat[subcat['OBJTYPE'] == 'TGT']
-
-        # Add columns for QN best and second-best confident lines
-        qn_c_lines = ['C_LYA', 'C_CIV', 'C_CIII', 'C_MgII', 'C_Hbeta', 'C_Halpha']
-        all_c_lines = np.vstack([subcat[c_line_col] for c_line_col in qn_c_lines]).T
-
-        # Replace NaNs with -Infs for sorting reasons below
-        all_c_lines = np.where(np.isnan(all_c_lines), -np.inf, all_c_lines)
-
-        # Partition the array by the second and top-best lines
-        all_c_lines_sorted = np.partition(all_c_lines, kth=(-2, -1), axis=1)
-
-        subcat['QN_C_LINE_BEST'] = all_c_lines_sorted[:, -1]
-        subcat['QN_C_LINE_SECOND_BEST'] = all_c_lines_sorted[:, -2]
-
-        # Remove stars except for possible mid/high-confidence QN cases
-        is_star = (subcat['SPECTYPE'] == 'STAR') & (subcat['Z'] <= 0.001)
-        qn_high_conf_50 = subcat['QN_C_LINE_BEST'] > 0.5
-        subcat = subcat[(~is_star) & qn_high_conf_50]
-
+    for subcat_key, subcat in subcats.items():
         # Prepare the output file
         primary_hdu = fits.PrimaryHDU()
-        subcat_hdu = fits.BinTableHDU(subcat, name='QSO_CAT')
+        subcat_hdu = fits.BinTableHDU(subcat, name='QSO_CAT' if out_prefix == 'QSO' else 'ZCATALOG')
         hdu_list = fits.HDUList([primary_hdu, subcat_hdu])
 
         # Write the file out copying
         if len(subcat_key) == 3:
             survey, program, nside1_hp = subcat_key
-            hdu_list.writeto(f'{out_dir}/QSO_cat_{specprod}_{survey}_{program}_nside1_hp{nside1_hp:02d}'
+            hdu_list.writeto(f'{out_dir}/{out_prefix}_cat_{specprod}_{survey}_{program}_nside1_hp{nside1_hp:02d}'
                              f'_healpix_all_targets_v{version}.fits', overwrite=True, checksum=True)
         else:
             survey, program = subcat_key
-            hdu_list.writeto(f'{out_dir}/QSO_cat_{specprod}_{survey}_{program}_healpix_all_targets_v{version}.fits',
-                             overwrite=True, checksum=True)
-
-
-def split_zcat(catalog_file: str, out_dir: str, specprod: str, version: int|float) -> None:
-    """Splits an input monolithic Redshift catalog into sub-catalogs split by Survey-Program(-nside1_hpXX).
-
-    Most sub-catalogs will just be split by Survey-Program with the exception of ``Main-Bright`` and ``Main-Dark``.
-    These sub-catalogs are often very large, and thus we further split by HEALPix of nside=1.
-    This is largely to match the subdivision adopted by FastSpec and FastPhot catalogs.
-
-    We also perform some cuts on the output catalogs, removing stars and low-redshift objects while retaining
-    high-confidence QuasarNet cases.
-    We also compute the confidence values of the best and second-best emission lines as found by QuasarNet.
-
-    Args:
-        catalog_file:
-            Path to monolithic QSO-Maker catalog to split.
-        out_dir:
-            Path to directory to save split catalogs to.
-        specprod:
-            DESI internal codename for data release.
-        version:
-            Version number to append to output catalogs.
-    """
-
-    # Read in the monolithic catalog
-    zcat = Table(fitsio.read(catalog_file, ext='ZCATALOG'))
-
-    # Group the catalog by Survey-Program
-    zcat = zcat.group_by(['SURVEY', 'PROGRAM'])
-
-    # Split the catalog by Survey-Program-(nside1_hpXX)
-    zcat_subcats = {}
-    for sp_grp, sp_grp_key in zip(zcat.groups, zcat.groups.keys.iterrows()):
-        match sp_grp_key:
-            # If catalog group is main-dark or main-bright, we need to further split by HEALPix (nside=1)
-            case ('main', 'dark') | ('main', 'bright'):
-                sp_hp_cat = split_by_healpix(sp_grp, nside=1)
-                for sphp_grp, sphp_grp_key in zip(sp_hp_cat.groups, sp_hp_cat.groups.keys.iterrows()):
-                    zcat_subcats[sphp_grp_key] = sp_hp_cat
-
-            # For all other cases, we just need the survey-program split
-            case _:
-                zcat_subcats[sp_grp_key] = sp_grp
-
-    # Write out all the catalogs
-    for subcat_key, subcat in zcat_subcats.items():
-        # Prepare the output file
-        primary_hdu = fits.PrimaryHDU()
-        subcat_hdu = fits.BinTableHDU(subcat, name='ZCATALOG')
-        hdu_list = fits.HDUList([primary_hdu, subcat_hdu])
-
-        if len(subcat_key) == 3:
-            survey, program, nside1_hp = subcat_key
-            hdu_list.writeto(f'{out_dir}/zpix_cat_{specprod}_{survey}_{program}'
-                             f'_nside1_hp{nside1_hp:02d}_v{version}.fits',
-                             overwrite=True, checksum=True)
-        else:
-            survey, program = subcat_key
-            hdu_list.writeto(f'{out_dir}/zpix_cat_{specprod}_{survey}_{program}_v{version}.fits',
+            hdu_list.writeto(f'{out_dir}/{out_prefix}_cat_{specprod}_{survey}_{program}'
+                             f'_healpix_all_targets_v{version}.fits',
                              overwrite=True, checksum=True)
 
 if __name__ == '__main__':
     # Split Fuji
     fuji_qsom = '/dvs_ro/cfs/cdirs/desi/users/edmondc/QSO_catalog/fuji/QSO_cat_fuji_healpix_all_targets_v2.fits'
     fuji_zcat = '/dvs_ro/cfs/cdirs/desi/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits'
-
     fuji_qso_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/qsom'
     fuji_zcat_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/zcat'
 
+    split_catalogs(fuji_qsom, out_prefix='QSO', out_dir=fuji_qso_outdir, specprod='fuji', version=2)
+    split_catalogs(fuji_zcat, out_prefix='zpix', out_dir=fuji_zcat_outdir, specprod='fuji', version=2)
+
+    # Split Iron
     iron_qsom = '/dvs_ro/cfs/cdirs/desi/science/gqp/agncatalog/qsomaker/iron/QSO_cat_iron_healpix_all_targets_v1.fits'
     iron_zcat = '/dvs_ro/cfs/cdirs/desi/spectro/redux/iron/zcatalog/v1/zall-pix-iron.fits'
-
     iron_qso_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/qsom'
     iron_zcat_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/zcat'
 
-
-    split_qsomaker(fuji_qsom, out_dir=fuji_qso_outdir, specprod='fuji', version=2)
-    split_zcat(fuji_zcat, out_dir=fuji_zcat_outdir, specprod='fuji', version=2)
-
-    split_qsomaker(iron_qsom, out_dir=iron_qso_outdir, specprod='iron', version=2)
-    split_zcat(iron_zcat, out_dir=iron_zcat_outdir, specprod='iron', version=2)
+    split_catalogs(iron_qsom, out_prefix='QSO', out_dir=iron_qso_outdir, specprod='iron', version=2)
+    split_catalogs(iron_zcat, out_prefix='zpix', out_dir=iron_zcat_outdir, specprod='iron', version=2)

--- a/AgnCats/py/split_input_catalogs.py
+++ b/AgnCats/py/split_input_catalogs.py
@@ -1,0 +1,189 @@
+"""
+split_input_catalogs.py
+Author: Benjamin Floyd
+
+This script generalizes the split_zpix_Loa.ipynb and split_QSOmaker_Loa.ipynb notebooks to split the Redshift and
+QSO-Maker catalogs respectively for the DR2/Loa DESI specprod to work on all DESI data releases.
+
+This has become necessary to match the organization of the most recent FastSpec and FastPhot catalogs.
+"""
+
+import numpy as np
+from astropy.table import Table
+import fitsio
+from pathlib import Path
+from desiutil.healpix import radec2hpix
+
+def split_by_healpix(catalog: Table, nside: int) -> Table:
+    """Takes a catalog that is already grouped by Survey-Program and further groups by HEALPix of size ``nside``.
+
+    Args:
+        catalog:
+            Table that is ideally already grouped by ``SURVEY`` and ``PROGRAM`` that we wish to further split by
+            HEALPix of a specified size.
+        nside:
+            Size of HEALPix we want to group our catalog by.
+
+    Returns:
+        Grouped Table by ``SURVEY``, ``PROGRAM``, and ``new_healpix`` of size ``nside``.
+    """
+
+    # Determine the new nside HEALPix number based on the RA and Dec of the object
+    catalog['new_healpix'] = radec2hpix(nside=nside, ra=catalog['TARGET_RA'], dec=catalog['TARGET_DEC'])
+
+    # Group by our new HEALPix numbers
+    catalog_grp = catalog.group_by(['SURVEY', 'PROGRAM', 'new_healpix'])
+
+    return catalog_grp
+
+def split_qsomaker(catalog_file: str, out_dir: str, specprod: str, version: int | float) -> None:
+    """Splits an input monolithic QSO-Maker catalog into sub-catalogs split by Survey-Program(-nside1_hpXX).
+
+    Most sub-catalogs will just be split by Survey-Program with the exception of ``Main-Bright`` and ``Main-Dark``.
+    These sub-catalogs are often very large, and thus we further split by HEALPix of nside=1.
+    This is largely to match the subdivision adopted by FastSpec and FastPhot catalogs.
+
+    We also perform some cuts on the output catalogs, removing stars and low-redshift objects while retaining
+    high-confidence QuasarNet cases.
+    We also compute the confidence values of the best and second-best emission lines as found by QuasarNet.
+
+    Args:
+        catalog_file:
+            Path to monolithic QSO-Maker catalog to split.
+        out_dir:
+            Path to directory to save split catalogs to.
+        specprod:
+            DESI internal codename for data release.
+        version:
+            Version number to append to output catalogs.
+    """
+
+    # Read in the monolithic catalog
+    qsom = Table(fitsio.read(catalog_file, ext='QSO_CAT'))
+
+    # Group the catalog by Survey-Program
+    qsom = qsom.group_by(['SURVEY', 'PROGRAM'])
+
+    # First, we will split the catalog by survey-program-nside1-hpXX
+    qsom_subcats = {}
+    for sp_grp, sp_grp_key in zip(qsom.groups, qsom.groups.keys.iterrows()):
+        match sp_grp_key:
+            # If catalog group is main-dark or main-bright, we need to further split by HEALPix (nside=1)
+            case ('main', 'dark') | ('main', 'bright'):
+                sp_hp_cat = split_by_healpix(sp_grp, nside=1)
+                for sphp_grp, sphp_grp_key in zip(sp_hp_cat.groups, sp_hp_cat.groups.keys.iterrows()):
+                    qsom_subcats[sphp_grp_key] = sphp_grp
+
+            # For all other cases, we just need the survey-program split
+            case _:
+                qsom_subcats[sp_grp_key] = sp_grp
+
+    # Iterate over the sub-catalogs to process and write out
+    for subcat_key, subcat in qsom_subcats.items():
+        # Keep only Target Object types if ``OBJTYPE`` column exists
+        if 'OBJTYPE' in subcat.colnames:
+            subcat = subcat[subcat['OBJTYPE'] == 'TGT']
+
+        # Add columns for QN best and second-best confident lines
+        qn_c_lines = ['C_LYA', 'C_CIV', 'C_CIII', 'C_MgII', 'C_Hbeta', 'C_Halpha']
+        all_c_lines = np.vstack([subcat[c_line_col] for c_line_col in qn_c_lines]).T
+
+        # Replace NaNs with -Infs for sorting reasons below
+        all_c_lines = np.where(np.isnan(all_c_lines), -np.inf, all_c_lines)
+
+        # Partition the array by the second and top-best lines
+        all_c_lines_sorted = np.partition(all_c_lines, kth=(-2, -1), axis=1)
+
+        subcat['QN_C_LINE_BEST'] = all_c_lines_sorted[:, -1]
+        subcat['QN_C_LINE_SECOND_BEST'] = all_c_lines_sorted[:, -2]
+
+        # Remove stars except for possible mid/high-confidence QN cases
+        is_star = (subcat['SPECTYPE'] == 'STAR') & (subcat['Z'] <= 0.001)
+        qn_high_conf_50 = subcat['QN_C_LINE_BEST'] > 0.5
+        subcat = subcat[(~is_star) & qn_high_conf_50]
+
+        # Write the file out copying
+        if len(subcat_key) == 3:
+            survey, program, nside1_hp = subcat_key
+            subcat.write(f'{out_dir}/QSO_cat_{specprod}_{survey}_{program}_nside1_hp{nside1_hp:02d}'
+                         f'_healpix_all_targets_v{version}.fits',
+                         hdu='QSO_CAT', overwrite=True)
+        else:
+            survey, program = subcat_key
+            subcat.write(f'{out_dir}/QSO_cat_{specprod}_{survey}_{program}_healpix_all_targets_v{version}.fits',
+                         hdu='QSO_CAT', overwrite=True)
+
+
+def split_zcat(catalog_file: str, out_dir: str, specprod: str, version: int|float) -> None:
+    """Splits an input monolithic Redshift catalog into sub-catalogs split by Survey-Program(-nside1_hpXX).
+
+    Most sub-catalogs will just be split by Survey-Program with the exception of ``Main-Bright`` and ``Main-Dark``.
+    These sub-catalogs are often very large, and thus we further split by HEALPix of nside=1.
+    This is largely to match the subdivision adopted by FastSpec and FastPhot catalogs.
+
+    We also perform some cuts on the output catalogs, removing stars and low-redshift objects while retaining
+    high-confidence QuasarNet cases.
+    We also compute the confidence values of the best and second-best emission lines as found by QuasarNet.
+
+    Args:
+        catalog_file:
+            Path to monolithic QSO-Maker catalog to split.
+        out_dir:
+            Path to directory to save split catalogs to.
+        specprod:
+            DESI internal codename for data release.
+        version:
+            Version number to append to output catalogs.
+    """
+
+    # Read in the monolithic catalog
+    zcat = Table(fitsio.read(catalog_file, ext='ZCATALOG'))
+
+    # Group the catalog by Survey-Program
+    zcat = zcat.group_by(['SURVEY', 'PROGRAM'])
+
+    # Split the catalog by Survey-Program-(nside1_hpXX)
+    zcat_subcats = {}
+    for sp_grp, sp_grp_key in zip(zcat.groups, zcat.groups.keys.iterrows()):
+        match sp_grp_key:
+            # If catalog group is main-dark or main-bright, we need to further split by HEALPix (nside=1)
+            case ('main', 'dark') | ('main', 'bright'):
+                sp_hp_cat = split_by_healpix(sp_grp, nside=1)
+                for sphp_grp, sphp_grp_key in zip(sp_hp_cat.groups, sp_hp_cat.groups.keys.iterrows()):
+                    zcat_subcats[sphp_grp_key] = sp_hp_cat
+
+            # For all other cases, we just need the survey-program split
+            case _:
+                zcat_subcats[sp_grp_key] = sp_grp
+
+    # Write out all the catalogs
+    for subcat_key, subcat in zcat_subcats.items():
+        if len(subcat_key) == 3:
+            survey, program, nside1_hp = subcat_key
+            subcat.write(f'{out_dir}/zpix_cat_{specprod}_{survey}_{program}_nside1_hp{nside1_hp:02d}_v{version}.fits',
+                         hdu='ZCATALOG', overwrite=True)
+        else:
+            survey, program = subcat_key
+            subcat.write(f'{out_dir}/zpix_cat_{specprod}_{survey}_{program}_v{version}.fits',
+                         hdu='ZCATALOG', overwrite=True)
+
+if __name__ == '__main__':
+    # Split Fuji
+    fuji_qsom = '/dvs_ro/cfs/cdirs/desi/users/edmondc/QSO_catalog/fuji/QSO_cat_fuji_healpix_all_targets_v2.fits'
+    fuji_zcat = '/dvs_ro/cfs/cdirs/desi/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits'
+
+    fuji_qso_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/qsom'
+    fuji_zcat_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/fuji/zcat'
+
+    iron_qsom = '/dvs_ro/cfs/cdirs/desi/users/edmondc/QSO_catalog/fuji/QSO_cat_fuji_healpix_all_targets_v2.fits'
+    iron_zcat = '/dvs_ro/cfs/cdirs/desi/public/edr/vac/edr/zcat/fuji/v1.0/zall-pix-edr-vac.fits'
+
+    iron_qso_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/qsom'
+    iron_zcat_outdir = '/pscratch/sd/b/bfloyd/agngal_incats_tmp/iron/zcat'
+
+
+    split_qsomaker(fuji_qsom, out_dir=fuji_qso_outdir, specprod='fuji', version=2)
+    split_zcat(fuji_zcat, out_dir=fuji_zcat_outdir, specprod='fuji', version=2)
+
+    split_qsomaker(iron_qsom, out_dir=iron_qso_outdir, specprod='iron', version=2)
+    split_zcat(iron_zcat, out_dir=iron_zcat_outdir, specprod='iron', version=2)

--- a/AgnCats/py/split_input_catalogs.py
+++ b/AgnCats/py/split_input_catalogs.py
@@ -8,12 +8,11 @@ QSO-Maker catalogs respectively for the DR2/Loa DESI specprod to work on all DES
 This has become necessary to match the organization of the most recent FastSpec and FastPhot catalogs.
 """
 
-import numpy as np
-from astropy.table import Table
 import fitsio
-from pathlib import Path
-from desiutil.healpix import radec2hpix
 from astropy.io import fits
+from astropy.table import Table
+from desiutil.healpix import radec2hpix
+
 
 def split_by_healpix(catalog: Table, nside: int) -> Table:
     """Takes a catalog that is already grouped by Survey-Program and further groups by HEALPix of size ``nside``.


### PR DESCRIPTION
Added script to split the Fuji and Iron input catalogs into survey-program subcatalogs same as Loa. This allowed for a lot of code simplification as all data releases now share the same expected input and output structure. Crucially, this allows for all data releases to benefit from parallelization speed-ups.

Known issues: 
 - Some path names need to be changed to run outside userspace. 
 - The inclusion of LOGMSTAR_IVAR for Iron and Loa puts this column first in the output extension 2. This can be fixed with manual intervention in the configuration files, but we should consider an automated solution if we care about the ascetics of the ordering of the output column names.